### PR TITLE
Override CodeActionKind type to StrEnum

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -2,13 +2,17 @@
 import json
 
 from lsp_schema import MetaModel
+from typing import Dict, Literal
 from utils.generate_enumerations import generate_enumerations
 from utils.generate_structures import generate_structures
 from utils.generate_type_aliases import generate_type_aliases
 from utils.helpers import get_new_literal_structures, reset_new_literal_structures, StructureKind
 
 
-BITWISE_ENUMS = ['WatchKind']
+ENUM_OVERRIDES = {
+    'CodeActionKind': 'StrEnum',
+    'WatchKind': 'IntFlag',
+}  # type: Dict[str, Literal['StrEnum', 'IntFlag']]
 
 
 def generate(preferred_structure_kind: StructureKind, output: str) -> None:
@@ -23,7 +27,7 @@ def generate(preferred_structure_kind: StructureKind, output: str) -> None:
             f"# LSP v{specification_version}\n",
             "from typing_extensions import NotRequired",
             "from typing import Dict, List, Literal, TypedDict, Union",
-            "from enum import Enum, IntEnum, IntFlag\n\n",
+            "from enum import Enum, IntEnum, IntFlag, StrEnum\n\n",
             "URI = str",
             "DocumentUri = str",
             "Uint = int",
@@ -31,7 +35,7 @@ def generate(preferred_structure_kind: StructureKind, output: str) -> None:
         ])
 
         content += '\n\n\n'
-        content += '\n\n\n'.join(generate_enumerations(lsp_json['enumerations'], BITWISE_ENUMS))
+        content += '\n\n\n'.join(generate_enumerations(lsp_json['enumerations'], ENUM_OVERRIDES))
         content += '\n\n'
         content += '\n'.join(generate_type_aliases(lsp_json['typeAliases'], preferred_structure_kind))
         content += '\n\n\n'

--- a/lsp_types.py
+++ b/lsp_types.py
@@ -3,7 +3,7 @@
 
 from typing_extensions import NotRequired
 from typing import Dict, List, Literal, TypedDict, Union
-from enum import Enum, IntEnum, IntFlag
+from enum import Enum, IntEnum, IntFlag, StrEnum
 
 
 URI = str
@@ -326,7 +326,7 @@ class DocumentHighlightKind(IntEnum):
     """ Write-access of a symbol, like writing to a variable. """
 
 
-class CodeActionKind(Enum):
+class CodeActionKind(StrEnum):
     """ A set of predefined code action kinds """
     Empty = ''
     """ Empty kind. """

--- a/lsp_types_sublime_text_33.py
+++ b/lsp_types_sublime_text_33.py
@@ -3,7 +3,7 @@
 
 from typing_extensions import NotRequired
 from typing import Dict, List, Literal, TypedDict, Union
-from enum import Enum, IntEnum, IntFlag
+from enum import Enum, IntEnum, IntFlag, StrEnum
 
 
 URI = str
@@ -326,7 +326,7 @@ class DocumentHighlightKind(IntEnum):
     """ Write-access of a symbol, like writing to a variable. """
 
 
-class CodeActionKind(Enum):
+class CodeActionKind(StrEnum):
     """ A set of predefined code action kinds """
     Empty = ''
     """ Empty kind. """

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+    "pythonVersion": "3.11"
+}

--- a/utils/generate_enumerations.py
+++ b/utils/generate_enumerations.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from lsp_schema import Enumeration, EnumerationEntry
-from typing import List
+from typing import Dict, List, Literal
 from utils.helpers import capitalize, format_comment, indentation
 import keyword
 
@@ -27,17 +27,15 @@ def format_enumeration_values(values: List[EnumerationEntry], kind: EnumKind) ->
     return f"\n{indentation}".join(result)
 
 
-def generate_enumerations(enumerations: List[Enumeration], bitwise_enums: List[str]) -> List[str]:
+def generate_enumerations(enumerations: List[Enumeration], overrides: Dict[str, Literal['StrEnum', 'IntFlag']]) -> List[str]:
 
     def toString(enumeration: Enumeration) -> str:
         result = ''
         symbol_name = enumeration['name']
         documentation = format_comment(enumeration.get('documentation'), indentation)
         kind = EnumKind.String if enumeration['type']['name'] == 'string' else EnumKind.Number
-        if kind == EnumKind.String:
-            enum_class = 'Enum'
-        else:
-            enum_class = 'IntFlag' if symbol_name in bitwise_enums else 'IntEnum'
+        enum_class_override = overrides.get(symbol_name)
+        enum_class = enum_class_override or ('Enum' if kind == EnumKind.String else 'IntEnum')
         values = format_enumeration_values(enumeration['values'], kind)
         result += f"class {symbol_name}({enum_class}):\n"
         if documentation:


### PR DESCRIPTION
@jwortmann Sorry if you were working on it yourself... :/

One related thought that came to my mind now...
@deathaxe posted this screenshot of LSP running in 3.8 host:

![Screenshot 2022-10-05 at 22 53 19](https://user-images.githubusercontent.com/153197/194161396-f8c77528-c5d9-4dbd-8d48-f96ff5430d13.png)

That suggests that the actual `Enum` type from `typing` is not compatible with some cases. Possibly when passing to ST APIs like `run_command` but not sure. So it might be that if we'd want to use actual types from `typing`, we'd need to use `StrEnum` instead of `Enum`.

This is not actually a problem for LSP now as we've changed the version check in `.typing` to `>=3.11` so we are not using actual `typing` types but our dummy aliases during runtime. But it would become a problem if we'd want to use actual types in the future.

fyi: @predragnikolic @rwols 