### PR TITLE
update schema

### DIFF
--- a/lsp_schema.py
+++ b/lsp_schema.py
@@ -12,6 +12,7 @@ class EnumerationType(TypedDict):
 
 
 class EnumerationEntry(TypedDict):
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     name: str
     proposed: NotRequired[bool]
@@ -26,6 +27,7 @@ class ReferenceType(TypedDict):
 
 
 class Property(TypedDict):
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     name: str
     optional: NotRequired[bool]
@@ -71,6 +73,7 @@ class BooleanLiteralType(TypedDict):
 
 
 class Enumeration(TypedDict):
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     name: str
     proposed: NotRequired[bool]
@@ -106,6 +109,7 @@ MessageDirection = Literal["clientToServer", "serverToClient", "both"]
 
 
 class Notification(TypedDict):
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     messageDirection: MessageDirection
     method: str
@@ -119,6 +123,7 @@ class Notification(TypedDict):
 
 
 class Request(TypedDict):
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     errorData: NotRequired[_Type]
     messageDirection: MessageDirection
@@ -133,6 +138,7 @@ class Request(TypedDict):
 
 
 class Structure(TypedDict):
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     extends: NotRequired[List[_Type]]
     """Structures extended from. This structures form a polymorphic type hierarchy."""
@@ -146,6 +152,7 @@ class Structure(TypedDict):
 
 class StructureLiteral(TypedDict):
     """Defines a unnamed structure of an object literal."""
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     properties: List[Property]
     proposed: NotRequired[bool]
@@ -166,6 +173,7 @@ class TupleType(TypedDict):
 
 class TypeAlias(TypedDict):
     """ Defines a type alias. (e.g. `type Definition = Location | LocationLink`)"""
+    deprecated: NotRequired[str]
     documentation: NotRequired[str]
     name: str
     proposed: NotRequired[bool]

--- a/lsp_types.py
+++ b/lsp_types.py
@@ -559,7 +559,7 @@ class TokenFormat(Enum):
 
 
 Definition = Union['Location', List['Location']]
-""" The definition of a symbol represented as one or many [locations](#Location).
+""" The definition of a symbol represented as one or many {@link Location locations}.
 For most programming languages there is only one location at which a symbol is
 defined.
 
@@ -569,7 +569,7 @@ by the client. """
 DefinitionLink = 'LocationLink'
 """ Information about where a symbol is defined.
 
-Provides additional metadata over normal [location](#Location) definitions, including the range of
+Provides additional metadata over normal {@link Location location} definitions, including the range of
 the defining symbol """
 
 LSPArray = List['LSPAny']
@@ -585,12 +585,12 @@ optional as well.
 @since 3.17.0 """
 
 Declaration = Union['Location', List['Location']]
-""" The declaration of a symbol representation as one or many [locations](#Location). """
+""" The declaration of a symbol representation as one or many {@link Location locations}. """
 
 DeclarationLink = 'LocationLink'
 """ Information about where a symbol is declared.
 
-Provides additional metadata over normal [location](#Location) declarations, including the range of
+Provides additional metadata over normal {@link Location location} declarations, including the range of
 the declaring symbol.
 
 Servers should prefer returning `DeclarationLink` over `Declaration` if supported
@@ -616,14 +616,14 @@ pull request.
 
 PrepareRenameResult = Union['Range', '__PrepareRenameResult_Type_1', '__PrepareRenameResult_Type_2']
 
-ProgressToken = Union[int, str]
-
 DocumentSelector = List['DocumentFilter']
 """ A document selector is the combination of one or many document filters.
 
 @sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;
 
 The use of a string as a document filter is deprecated @since 3.16.0. """
+
+ProgressToken = Union[int, str]
 
 ChangeAnnotationIdentifier = str
 """ An identifier to refer to a change annotation stored with a workspace edit. """
@@ -657,6 +657,10 @@ a notebook cell document.
 
 @since 3.17.0 - proposed support for NotebookCellTextDocumentFilter. """
 
+LSPObject = Dict[str, 'LSPAny']
+""" LSP object definition.
+@since 3.17.0 """
+
 GlobPattern = Union['Pattern', 'RelativePattern']
 """ The glob pattern. Either a string pattern or a relative pattern.
 
@@ -664,8 +668,8 @@ GlobPattern = Union['Pattern', 'RelativePattern']
 
 TextDocumentFilter = Union['__TextDocumentFilter_Type_6', '__TextDocumentFilter_Type_7', '__TextDocumentFilter_Type_8']
 """ A document filter denotes a document by different properties like
-the [language](#TextDocument.languageId), the [scheme](#Uri.scheme) of
-its resource, or a glob-pattern that is applied to the [path](#TextDocument.fileName).
+the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
 
 Glob patterns can have the following syntax:
 - `*` to match one or more characters in a path segment
@@ -768,14 +772,8 @@ class ConfigurationParams(TypedDict):
     items: List['ConfigurationItem']
 
 
-class PartialResultParams(TypedDict):
-    partialResultToken: NotRequired['ProgressToken']
-    """ An optional token that a server can use to report partial results (e.g. streaming) to
-    the client. """
-
-
 class DocumentColorParams(TypedDict):
-    """ Parameters for a [DocumentColorRequest](#DocumentColorRequest). """
+    """ Parameters for a {@link DocumentColorRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     workDoneToken: NotRequired['ProgressToken']
@@ -803,7 +801,7 @@ class DocumentColorRegistrationOptions(TypedDict):
 
 
 class ColorPresentationParams(TypedDict):
-    """ Parameters for a [ColorPresentationRequest](#ColorPresentationRequest). """
+    """ Parameters for a {@link ColorPresentationRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     color: 'Color'
@@ -823,12 +821,12 @@ class ColorPresentation(TypedDict):
     picker header. By default this is also the text that is inserted when selecting
     this color presentation. """
     textEdit: NotRequired['TextEdit']
-    """ An [edit](#TextEdit) which is applied to a document when selecting
-    this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+    """ An {@link TextEdit edit} which is applied to a document when selecting
+    this presentation for the color.  When `falsy` the {@link ColorPresentation.label label}
     is used. """
     additionalTextEdits: NotRequired[List['TextEdit']]
-    """ An optional array of additional [text edits](#TextEdit) that are applied when
-    selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves. """
+    """ An optional array of additional {@link TextEdit text edits} that are applied when
+    selecting this color presentation. Edits must not overlap with the main {@link ColorPresentation.textEdit edit} nor with themselves. """
 
 
 class WorkDoneProgressOptions(TypedDict):
@@ -843,7 +841,7 @@ class TextDocumentRegistrationOptions(TypedDict):
 
 
 class FoldingRangeParams(TypedDict):
-    """ Parameters for a [FoldingRangeRequest](#FoldingRangeRequest). """
+    """ Parameters for a {@link FoldingRangeRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     workDoneToken: NotRequired['ProgressToken']
@@ -869,7 +867,7 @@ class FoldingRange(TypedDict):
     kind: NotRequired['FoldingRangeKind']
     """ Describes the kind of the folding range such as `comment' or 'region'. The kind
     is used to categorize folding ranges and used by commands like 'Fold all comments'.
-    See [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds. """
+    See {@link FoldingRangeKind} for an enumeration of standardized kinds. """
     collapsedText: NotRequired[str]
     """ The text that the client should show when the specified range is
     collapsed. If not defined or not supported by the client, a default
@@ -925,7 +923,7 @@ class SelectionRange(TypedDict):
     """ A selection range represents a part of a selection hierarchy. A selection range
     may have a parent selection range that contains it. """
     range: 'Range'
-    """ The [range](#Range) of this selection range. """
+    """ The {@link Range range} of this selection range. """
     parent: NotRequired['SelectionRange']
     """ The parent selection range containing this range. Therefore `parent.range` must contain `this.range`. """
 
@@ -980,7 +978,7 @@ class CallHierarchyItem(TypedDict):
     """ The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code. """
     selectionRange: 'Range'
     """ The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.
-    Must be contained by the [`range`](#CallHierarchyItem.range). """
+    Must be contained by the {@link CallHierarchyItem.range `range`}. """
     data: NotRequired['LSPAny']
     """ A data entry field that is preserved between a call hierarchy prepare and
     incoming calls or outgoing calls requests. """
@@ -1014,7 +1012,7 @@ CallHierarchyIncomingCall = TypedDict('CallHierarchyIncomingCall', {
     # The item that makes the call.
     'from': 'CallHierarchyItem',
     # The ranges at which the calls appear. This is relative to the caller
-    # denoted by [`this.from`](#CallHierarchyIncomingCall.from).
+    # denoted by {@link CallHierarchyIncomingCall.from `this.from`}.
     'fromRanges': List['Range'],
 })
 """ Represents an incoming call, e.g. a caller of a method or constructor.
@@ -1042,8 +1040,8 @@ class CallHierarchyOutgoingCall(TypedDict):
     """ The item that is called. """
     fromRanges: List['Range']
     """ The range at which this item is called. This is the range relative to the caller, e.g the item
-    passed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)
-    and not [`this.to`](#CallHierarchyOutgoingCall.to). """
+    passed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}
+    and not {@link CallHierarchyOutgoingCall.to `this.to`}. """
 
 
 class SemanticTokensParams(TypedDict):
@@ -1324,7 +1322,7 @@ class TypeHierarchyItem(TypedDict):
     selectionRange: 'Range'
     """ The range that should be selected and revealed when this symbol is being
     picked, e.g. the name of a function. Must be contained by the
-    [`range`](#TypeHierarchyItem.range). """
+    {@link TypeHierarchyItem.range `range`}. """
     data: NotRequired['LSPAny']
     """ A data entry field that is preserved between a type hierarchy prepare and
     supertypes or subtypes requests. It could also be used to identify the
@@ -1642,7 +1640,7 @@ class InitializeParams(TypedDict):
     """ The capabilities provided by the client (editor or tool) """
     initializationOptions: NotRequired['LSPAny']
     """ User provided initialization options. """
-    trace: NotRequired[Union[Literal['off'], Literal['messages'], Literal['compact'], Literal['verbose']]]
+    trace: NotRequired['TraceValues']
     """ The initial trace setting. If omitted trace is disabled ('off'). """
     workspaceFolders: NotRequired[Union[List['WorkspaceFolder'], None]]
     """ The workspace folders configured in the client when the server starts.
@@ -1873,15 +1871,15 @@ class CompletionItem(TypedDict):
     item of those that match best is selected. """
     sortText: NotRequired[str]
     """ A string that should be used when comparing this item
-    with other items. When `falsy` the [label](#CompletionItem.label)
+    with other items. When `falsy` the {@link CompletionItem.label label}
     is used. """
     filterText: NotRequired[str]
     """ A string that should be used when filtering a set of
-    completion items. When `falsy` the [label](#CompletionItem.label)
+    completion items. When `falsy` the {@link CompletionItem.label label}
     is used. """
     insertText: NotRequired[str]
     """ A string that should be inserted into a document when selecting
-    this completion. When `falsy` the [label](#CompletionItem.label)
+    this completion. When `falsy` the {@link CompletionItem.label label}
     is used.
 
     The `insertText` is subject to interpretation by the client side.
@@ -1905,9 +1903,9 @@ class CompletionItem(TypedDict):
 
     @since 3.16.0 """
     textEdit: NotRequired[Union['TextEdit', 'InsertReplaceEdit']]
-    """ An [edit](#TextEdit) which is applied to a document when selecting
+    """ An {@link TextEdit edit} which is applied to a document when selecting
     this completion. When an edit is provided the value of
-    [insertText](#CompletionItem.insertText) is ignored.
+    {@link CompletionItem.insertText insertText} is ignored.
 
     Most editors support two different operations when accepting a completion
     item. One is to insert a completion text and the other is to replace an
@@ -1937,9 +1935,9 @@ class CompletionItem(TypedDict):
 
     @since 3.17.0 """
     additionalTextEdits: NotRequired[List['TextEdit']]
-    """ An optional array of additional [text edits](#TextEdit) that are applied when
+    """ An optional array of additional {@link TextEdit text edits} that are applied when
     selecting this completion. Edits must not overlap (including the same insert position)
-    with the main [edit](#CompletionItem.textEdit) nor with themselves.
+    with the main {@link CompletionItem.textEdit edit} nor with themselves.
 
     Additional text edits should be used to change text unrelated to the current cursor position
     (for example adding an import statement at the top of the file if the completion item will
@@ -1949,16 +1947,16 @@ class CompletionItem(TypedDict):
     then type that character. *Note* that all commit characters should have `length=1` and that superfluous
     characters will be ignored. """
     command: NotRequired['Command']
-    """ An optional [command](#Command) that is executed *after* inserting this completion. *Note* that
+    """ An optional {@link Command command} that is executed *after* inserting this completion. *Note* that
     additional modifications to the current document should be described with the
-    [additionalTextEdits](#CompletionItem.additionalTextEdits)-property. """
+    {@link CompletionItem.additionalTextEdits additionalTextEdits}-property. """
     data: NotRequired['LSPAny']
     """ A data entry field that is preserved on a completion item between a
-    [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest). """
+    {@link CompletionRequest} and a {@link CompletionResolveRequest}. """
 
 
 class CompletionList(TypedDict):
-    """ Represents a collection of [completion items](#CompletionItem) to be presented
+    """ Represents a collection of {@link CompletionItem completion items} to be presented
     in the editor. """
     isIncomplete: bool
     """ This list it not complete. Further typing results in recomputing this list.
@@ -1984,7 +1982,7 @@ class CompletionList(TypedDict):
 
 
 class CompletionRegistrationOptions(TypedDict):
-    """ Registration options for a [CompletionRequest](#CompletionRequest). """
+    """ Registration options for a {@link CompletionRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2017,7 +2015,7 @@ class CompletionRegistrationOptions(TypedDict):
 
 
 class HoverParams(TypedDict):
-    """ Parameters for a [HoverRequest](#HoverRequest). """
+    """ Parameters for a {@link HoverRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     position: 'Position'
@@ -2036,14 +2034,14 @@ class Hover(TypedDict):
 
 
 class HoverRegistrationOptions(TypedDict):
-    """ Registration options for a [HoverRequest](#HoverRequest). """
+    """ Registration options for a {@link HoverRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
 
 
 class SignatureHelpParams(TypedDict):
-    """ Parameters for a [SignatureHelpRequest](#SignatureHelpRequest). """
+    """ Parameters for a {@link SignatureHelpRequest}. """
     context: NotRequired['SignatureHelpContext']
     """ The signature help context. This is only available if the client specifies
     to send this using the client capability `textDocument.signatureHelp.contextSupport === true`
@@ -2084,7 +2082,7 @@ class SignatureHelp(TypedDict):
 
 
 class SignatureHelpRegistrationOptions(TypedDict):
-    """ Registration options for a [SignatureHelpRequest](#SignatureHelpRequest). """
+    """ Registration options for a {@link SignatureHelpRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2100,7 +2098,7 @@ class SignatureHelpRegistrationOptions(TypedDict):
 
 
 class DefinitionParams(TypedDict):
-    """ Parameters for a [DefinitionRequest](#DefinitionRequest). """
+    """ Parameters for a {@link DefinitionRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     position: 'Position'
@@ -2113,14 +2111,14 @@ class DefinitionParams(TypedDict):
 
 
 class DefinitionRegistrationOptions(TypedDict):
-    """ Registration options for a [DefinitionRequest](#DefinitionRequest). """
+    """ Registration options for a {@link DefinitionRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
 
 
 class ReferenceParams(TypedDict):
-    """ Parameters for a [ReferencesRequest](#ReferencesRequest). """
+    """ Parameters for a {@link ReferencesRequest}. """
     context: 'ReferenceContext'
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
@@ -2134,14 +2132,14 @@ class ReferenceParams(TypedDict):
 
 
 class ReferenceRegistrationOptions(TypedDict):
-    """ Registration options for a [ReferencesRequest](#ReferencesRequest). """
+    """ Registration options for a {@link ReferencesRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
 
 
 class DocumentHighlightParams(TypedDict):
-    """ Parameters for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+    """ Parameters for a {@link DocumentHighlightRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     position: 'Position'
@@ -2160,18 +2158,18 @@ class DocumentHighlight(TypedDict):
     range: 'Range'
     """ The range this highlight applies to. """
     kind: NotRequired['DocumentHighlightKind']
-    """ The highlight kind, default is [text](#DocumentHighlightKind.Text). """
+    """ The highlight kind, default is {@link DocumentHighlightKind.Text text}. """
 
 
 class DocumentHighlightRegistrationOptions(TypedDict):
-    """ Registration options for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+    """ Registration options for a {@link DocumentHighlightRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
 
 
 class DocumentSymbolParams(TypedDict):
-    """ Parameters for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+    """ Parameters for a {@link DocumentSymbolRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The text document. """
     workDoneToken: NotRequired['ProgressToken']
@@ -2245,7 +2243,7 @@ class DocumentSymbol(TypedDict):
 
 
 class DocumentSymbolRegistrationOptions(TypedDict):
-    """ Registration options for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+    """ Registration options for a {@link DocumentSymbolRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2257,7 +2255,7 @@ class DocumentSymbolRegistrationOptions(TypedDict):
 
 
 class CodeActionParams(TypedDict):
-    """ The parameters of a [CodeActionRequest](#CodeActionRequest). """
+    """ The parameters of a {@link CodeActionRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document in which the command was invoked. """
     range: 'Range'
@@ -2336,7 +2334,7 @@ class CodeAction(TypedDict):
 
 
 class CodeActionRegistrationOptions(TypedDict):
-    """ Registration options for a [CodeActionRequest](#CodeActionRequest). """
+    """ Registration options for a {@link CodeActionRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2353,7 +2351,7 @@ class CodeActionRegistrationOptions(TypedDict):
 
 
 class WorkspaceSymbolParams(TypedDict):
-    """ The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+    """ The parameters of a {@link WorkspaceSymbolRequest}. """
     query: str
     """ A query string to filter symbols by. Clients may send an empty
     string here to request all symbols. """
@@ -2395,7 +2393,7 @@ class WorkspaceSymbol(TypedDict):
 
 
 class WorkspaceSymbolRegistrationOptions(TypedDict):
-    """ Registration options for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+    """ Registration options for a {@link WorkspaceSymbolRequest}. """
     resolveProvider: NotRequired[bool]
     """ The server provides support to resolve additional
     information for a workspace symbol.
@@ -2404,7 +2402,7 @@ class WorkspaceSymbolRegistrationOptions(TypedDict):
 
 
 class CodeLensParams(TypedDict):
-    """ The parameters of a [CodeLensRequest](#CodeLensRequest). """
+    """ The parameters of a {@link CodeLensRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document to request code lens for. """
     workDoneToken: NotRequired['ProgressToken']
@@ -2415,7 +2413,7 @@ class CodeLensParams(TypedDict):
 
 
 class CodeLens(TypedDict):
-    """ A code lens represents a [command](#Command) that should be shown along with
+    """ A code lens represents a {@link Command command} that should be shown along with
     source text, like the number of references, a way to run tests, etc.
 
     A code lens is _unresolved_ when no command is associated to it. For performance
@@ -2426,12 +2424,12 @@ class CodeLens(TypedDict):
     """ The command this code lens represents. """
     data: NotRequired['LSPAny']
     """ A data entry field that is preserved on a code lens item between
-    a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]
+    a {@link CodeLensRequest} and a [CodeLensResolveRequest]
     (#CodeLensResolveRequest) """
 
 
 class CodeLensRegistrationOptions(TypedDict):
-    """ Registration options for a [CodeLensRequest](#CodeLensRequest). """
+    """ Registration options for a {@link CodeLensRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2440,7 +2438,7 @@ class CodeLensRegistrationOptions(TypedDict):
 
 
 class DocumentLinkParams(TypedDict):
-    """ The parameters of a [DocumentLinkRequest](#DocumentLinkRequest). """
+    """ The parameters of a {@link DocumentLinkRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document to provide document links for. """
     workDoneToken: NotRequired['ProgressToken']
@@ -2471,7 +2469,7 @@ class DocumentLink(TypedDict):
 
 
 class DocumentLinkRegistrationOptions(TypedDict):
-    """ Registration options for a [DocumentLinkRequest](#DocumentLinkRequest). """
+    """ Registration options for a {@link DocumentLinkRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2480,7 +2478,7 @@ class DocumentLinkRegistrationOptions(TypedDict):
 
 
 class DocumentFormattingParams(TypedDict):
-    """ The parameters of a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+    """ The parameters of a {@link DocumentFormattingRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document to format. """
     options: 'FormattingOptions'
@@ -2490,14 +2488,14 @@ class DocumentFormattingParams(TypedDict):
 
 
 class DocumentFormattingRegistrationOptions(TypedDict):
-    """ Registration options for a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+    """ Registration options for a {@link DocumentFormattingRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
 
 
 class DocumentRangeFormattingParams(TypedDict):
-    """ The parameters of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+    """ The parameters of a {@link DocumentRangeFormattingRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document to format. """
     range: 'Range'
@@ -2509,14 +2507,14 @@ class DocumentRangeFormattingParams(TypedDict):
 
 
 class DocumentRangeFormattingRegistrationOptions(TypedDict):
-    """ Registration options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+    """ Registration options for a {@link DocumentRangeFormattingRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
 
 
 class DocumentOnTypeFormattingParams(TypedDict):
-    """ The parameters of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+    """ The parameters of a {@link DocumentOnTypeFormattingRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document to format. """
     position: 'Position'
@@ -2533,7 +2531,7 @@ class DocumentOnTypeFormattingParams(TypedDict):
 
 
 class DocumentOnTypeFormattingRegistrationOptions(TypedDict):
-    """ Registration options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+    """ Registration options for a {@link DocumentOnTypeFormattingRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2544,21 +2542,21 @@ class DocumentOnTypeFormattingRegistrationOptions(TypedDict):
 
 
 class RenameParams(TypedDict):
-    """ The parameters of a [RenameRequest](#RenameRequest). """
+    """ The parameters of a {@link RenameRequest}. """
     textDocument: 'TextDocumentIdentifier'
     """ The document to rename. """
     position: 'Position'
     """ The position at which this request was sent. """
     newName: str
     """ The new name of the symbol. If the given name is not valid the
-    request must return a [ResponseError](#ResponseError) with an
+    request must return a {@link ResponseError} with an
     appropriate message set. """
     workDoneToken: NotRequired['ProgressToken']
     """ An optional token that a server can use to report work done progress. """
 
 
 class RenameRegistrationOptions(TypedDict):
-    """ Registration options for a [RenameRequest](#RenameRequest). """
+    """ Registration options for a {@link RenameRequest}. """
     documentSelector: Union['DocumentSelector', None]
     """ A document selector to identify the scope of the registration. If set to null
     the document selector provided on the client side will be used. """
@@ -2578,7 +2576,7 @@ class PrepareRenameParams(TypedDict):
 
 
 class ExecuteCommandParams(TypedDict):
-    """ The parameters of a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+    """ The parameters of a {@link ExecuteCommandRequest}. """
     command: str
     """ The identifier of the actual command handler. """
     arguments: NotRequired[List['LSPAny']]
@@ -2588,7 +2586,7 @@ class ExecuteCommandParams(TypedDict):
 
 
 class ExecuteCommandRegistrationOptions(TypedDict):
-    """ Registration options for a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+    """ Registration options for a {@link ExecuteCommandRequest}. """
     commands: List[str]
     """ The commands to be executed on the server """
 
@@ -2709,8 +2707,14 @@ class WorkDoneProgressParams(TypedDict):
     """ An optional token that a server can use to report work done progress. """
 
 
+class PartialResultParams(TypedDict):
+    partialResultToken: NotRequired['ProgressToken']
+    """ An optional token that a server can use to report partial results (e.g. streaming) to
+    the client. """
+
+
 class LocationLink(TypedDict):
-    """ Represents the connection of two locations. Provides additional metadata over normal [locations](#Location),
+    """ Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},
     including an origin range. """
     originSelectionRange: NotRequired['Range']
     """ Span of the origin of this link.
@@ -3614,7 +3618,7 @@ class SignatureInformation(TypedDict):
 
 
 class SignatureHelpOptions(TypedDict):
-    """ Server Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest). """
+    """ Server Capabilities for a {@link SignatureHelpRequest}. """
     triggerCharacters: NotRequired[List[str]]
     """ List of characters that trigger signature help automatically. """
     retriggerCharacters: NotRequired[List[str]]
@@ -3628,7 +3632,7 @@ class SignatureHelpOptions(TypedDict):
 
 
 class DefinitionOptions(TypedDict):
-    """ Server Capabilities for a [DefinitionRequest](#DefinitionRequest). """
+    """ Server Capabilities for a {@link DefinitionRequest}. """
     workDoneProgress: NotRequired[bool]
 
 
@@ -3645,7 +3649,7 @@ class ReferenceOptions(TypedDict):
 
 
 class DocumentHighlightOptions(TypedDict):
-    """ Provider options for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+    """ Provider options for a {@link DocumentHighlightRequest}. """
     workDoneProgress: NotRequired[bool]
 
 
@@ -3667,7 +3671,7 @@ class BaseSymbolInformation(TypedDict):
 
 
 class DocumentSymbolOptions(TypedDict):
-    """ Provider options for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+    """ Provider options for a {@link DocumentSymbolRequest}. """
     label: NotRequired[str]
     """ A human-readable string that is shown when multiple outlines trees
     are shown for the same document.
@@ -3678,7 +3682,7 @@ class DocumentSymbolOptions(TypedDict):
 
 class CodeActionContext(TypedDict):
     """ Contains additional diagnostic information about the context in which
-    a [code action](#CodeActionProvider.provideCodeActions) is run. """
+    a {@link CodeActionProvider.provideCodeActions code action} is run. """
     diagnostics: List['Diagnostic']
     """ An array of diagnostics known on the client side overlapping the range provided to the
     `textDocument/codeAction` request. They are provided so that the server knows which
@@ -3697,7 +3701,7 @@ class CodeActionContext(TypedDict):
 
 
 class CodeActionOptions(TypedDict):
-    """ Provider options for a [CodeActionRequest](#CodeActionRequest). """
+    """ Provider options for a {@link CodeActionRequest}. """
     codeActionKinds: NotRequired[List['CodeActionKind']]
     """ CodeActionKinds that this server may return.
 
@@ -3712,7 +3716,7 @@ class CodeActionOptions(TypedDict):
 
 
 class WorkspaceSymbolOptions(TypedDict):
-    """ Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+    """ Server capabilities for a {@link WorkspaceSymbolRequest}. """
     resolveProvider: NotRequired[bool]
     """ The server provides support to resolve additional
     information for a workspace symbol.
@@ -3722,14 +3726,14 @@ class WorkspaceSymbolOptions(TypedDict):
 
 
 class CodeLensOptions(TypedDict):
-    """ Code Lens provider options of a [CodeLensRequest](#CodeLensRequest). """
+    """ Code Lens provider options of a {@link CodeLensRequest}. """
     resolveProvider: NotRequired[bool]
     """ Code lens has a resolve provider as well. """
     workDoneProgress: NotRequired[bool]
 
 
 class DocumentLinkOptions(TypedDict):
-    """ Provider options for a [DocumentLinkRequest](#DocumentLinkRequest). """
+    """ Provider options for a {@link DocumentLinkRequest}. """
     resolveProvider: NotRequired[bool]
     """ Document links have a resolve provider as well. """
     workDoneProgress: NotRequired[bool]
@@ -3756,17 +3760,17 @@ class FormattingOptions(TypedDict):
 
 
 class DocumentFormattingOptions(TypedDict):
-    """ Provider options for a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+    """ Provider options for a {@link DocumentFormattingRequest}. """
     workDoneProgress: NotRequired[bool]
 
 
 class DocumentRangeFormattingOptions(TypedDict):
-    """ Provider options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+    """ Provider options for a {@link DocumentRangeFormattingRequest}. """
     workDoneProgress: NotRequired[bool]
 
 
 class DocumentOnTypeFormattingOptions(TypedDict):
-    """ Provider options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+    """ Provider options for a {@link DocumentOnTypeFormattingRequest}. """
     firstTriggerCharacter: str
     """ A character on which formatting should be triggered, like `{`. """
     moreTriggerCharacter: NotRequired[List[str]]
@@ -3774,7 +3778,7 @@ class DocumentOnTypeFormattingOptions(TypedDict):
 
 
 class RenameOptions(TypedDict):
-    """ Provider options for a [RenameRequest](#RenameRequest). """
+    """ Provider options for a {@link RenameRequest}. """
     prepareProvider: NotRequired[bool]
     """ Renames should be checked and tested before being executed.
 
@@ -3783,7 +3787,7 @@ class RenameOptions(TypedDict):
 
 
 class ExecuteCommandOptions(TypedDict):
-    """ The server capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+    """ The server capabilities of a {@link ExecuteCommandRequest}. """
     commands: List[str]
     """ The commands to be executed on the server """
     workDoneProgress: NotRequired[bool]
@@ -3914,12 +3918,6 @@ class WorkspaceUnchangedDocumentDiagnosticReport(TypedDict):
     resultId: str
     """ A result id which will be sent on the next
     diagnostic request for the same document. """
-
-
-class LSPObject(TypedDict):
-    """ LSP object definition.
-    @since 3.17.0 """
-    pass
 
 
 class NotebookCell(TypedDict):
@@ -4409,7 +4407,7 @@ class DidChangeWatchedFilesClientCapabilities(TypedDict):
 
 
 class WorkspaceSymbolClientCapabilities(TypedDict):
-    """ Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+    """ Client capabilities for a {@link WorkspaceSymbolRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Symbol request supports dynamic registration. """
     symbolKind: NotRequired['__SymbolKind_Type_36']
@@ -4428,7 +4426,7 @@ class WorkspaceSymbolClientCapabilities(TypedDict):
 
 
 class ExecuteCommandClientCapabilities(TypedDict):
-    """ The client capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+    """ The client capabilities of a {@link ExecuteCommandRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Execute command supports dynamic registration. """
 
@@ -4568,7 +4566,7 @@ class HoverClientCapabilities(TypedDict):
 
 
 class SignatureHelpClientCapabilities(TypedDict):
-    """ Client Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest). """
+    """ Client Capabilities for a {@link SignatureHelpRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether signature help supports dynamic registration. """
     signatureInformation: NotRequired['__SignatureInformation_Type_45']
@@ -4594,7 +4592,7 @@ class DeclarationClientCapabilities(TypedDict):
 
 
 class DefinitionClientCapabilities(TypedDict):
-    """ Client Capabilities for a [DefinitionRequest](#DefinitionRequest). """
+    """ Client Capabilities for a {@link DefinitionRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether definition supports dynamic registration. """
     linkSupport: NotRequired[bool]
@@ -4628,19 +4626,19 @@ class ImplementationClientCapabilities(TypedDict):
 
 
 class ReferenceClientCapabilities(TypedDict):
-    """ Client Capabilities for a [ReferencesRequest](#ReferencesRequest). """
+    """ Client Capabilities for a {@link ReferencesRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether references supports dynamic registration. """
 
 
 class DocumentHighlightClientCapabilities(TypedDict):
-    """ Client Capabilities for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+    """ Client Capabilities for a {@link DocumentHighlightRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether document highlight supports dynamic registration. """
 
 
 class DocumentSymbolClientCapabilities(TypedDict):
-    """ Client Capabilities for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+    """ Client Capabilities for a {@link DocumentSymbolRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether document symbol supports dynamic registration. """
     symbolKind: NotRequired['__SymbolKind_Type_47']
@@ -4662,7 +4660,7 @@ class DocumentSymbolClientCapabilities(TypedDict):
 
 
 class CodeActionClientCapabilities(TypedDict):
-    """ The Client Capabilities of a [CodeActionRequest](#CodeActionRequest). """
+    """ The Client Capabilities of a {@link CodeActionRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether code action supports dynamic registration. """
     codeActionLiteralSupport: NotRequired['__CodeActionLiteralSupport_Type_49']
@@ -4701,13 +4699,13 @@ class CodeActionClientCapabilities(TypedDict):
 
 
 class CodeLensClientCapabilities(TypedDict):
-    """ The client capabilities  of a [CodeLensRequest](#CodeLensRequest). """
+    """ The client capabilities  of a {@link CodeLensRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether code lens supports dynamic registration. """
 
 
 class DocumentLinkClientCapabilities(TypedDict):
-    """ The client capabilities of a [DocumentLinkRequest](#DocumentLinkRequest). """
+    """ The client capabilities of a {@link DocumentLinkRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether document link supports dynamic registration. """
     tooltipSupport: NotRequired[bool]
@@ -4724,19 +4722,19 @@ class DocumentColorClientCapabilities(TypedDict):
 
 
 class DocumentFormattingClientCapabilities(TypedDict):
-    """ Client capabilities of a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+    """ Client capabilities of a {@link DocumentFormattingRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether formatting supports dynamic registration. """
 
 
 class DocumentRangeFormattingClientCapabilities(TypedDict):
-    """ Client capabilities of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+    """ Client capabilities of a {@link DocumentRangeFormattingRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether range formatting supports dynamic registration. """
 
 
 class DocumentOnTypeFormattingClientCapabilities(TypedDict):
-    """ Client capabilities of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+    """ Client capabilities of a {@link DocumentOnTypeFormattingRequest}. """
     dynamicRegistration: NotRequired[bool]
     """ Whether on type formatting supports dynamic registration. """
 
@@ -5022,7 +5020,7 @@ class __TextDocumentFilter_Type_6(TypedDict):
     language: str
     """ A language id, like `typescript`. """
     scheme: NotRequired[str]
-    """ A Uri [scheme](#Uri.scheme), like `file` or `untitled`. """
+    """ A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. """
     pattern: NotRequired[str]
     """ A glob pattern, like `*.{ts,js}`. """
 
@@ -5031,7 +5029,7 @@ class __TextDocumentFilter_Type_7(TypedDict):
     language: NotRequired[str]
     """ A language id, like `typescript`. """
     scheme: str
-    """ A Uri [scheme](#Uri.scheme), like `file` or `untitled`. """
+    """ A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. """
     pattern: NotRequired[str]
     """ A glob pattern, like `*.{ts,js}`. """
 
@@ -5040,7 +5038,7 @@ class __TextDocumentFilter_Type_8(TypedDict):
     language: NotRequired[str]
     """ A language id, like `typescript`. """
     scheme: NotRequired[str]
-    """ A Uri [scheme](#Uri.scheme), like `file` or `untitled`. """
+    """ A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. """
     pattern: str
     """ A glob pattern, like `*.{ts,js}`. """
 
@@ -5049,7 +5047,7 @@ class __NotebookDocumentFilter_Type_9(TypedDict):
     notebookType: str
     """ The type of the enclosing notebook. """
     scheme: NotRequired[str]
-    """ A Uri [scheme](#Uri.scheme), like `file` or `untitled`. """
+    """ A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. """
     pattern: NotRequired[str]
     """ A glob pattern. """
 
@@ -5058,7 +5056,7 @@ class __NotebookDocumentFilter_Type_10(TypedDict):
     notebookType: NotRequired[str]
     """ The type of the enclosing notebook. """
     scheme: str
-    """ A Uri [scheme](#Uri.scheme), like `file` or `untitled`. """
+    """ A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. """
     pattern: NotRequired[str]
     """ A glob pattern. """
 
@@ -5067,7 +5065,7 @@ class __NotebookDocumentFilter_Type_11(TypedDict):
     notebookType: NotRequired[str]
     """ The type of the enclosing notebook. """
     scheme: NotRequired[str]
-    """ A Uri [scheme](#Uri.scheme), like `file` or `untitled`. """
+    """ A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. """
     pattern: str
     """ A glob pattern. """
 

--- a/lsp_types_sublime_text_33.py
+++ b/lsp_types_sublime_text_33.py
@@ -559,7 +559,7 @@ class TokenFormat(Enum):
 
 
 Definition = Union['Location', List['Location']]
-""" The definition of a symbol represented as one or many [locations](#Location).
+""" The definition of a symbol represented as one or many {@link Location locations}.
 For most programming languages there is only one location at which a symbol is
 defined.
 
@@ -569,7 +569,7 @@ by the client. """
 DefinitionLink = 'LocationLink'
 """ Information about where a symbol is defined.
 
-Provides additional metadata over normal [location](#Location) definitions, including the range of
+Provides additional metadata over normal {@link Location location} definitions, including the range of
 the defining symbol """
 
 LSPArray = List['LSPAny']
@@ -585,12 +585,12 @@ optional as well.
 @since 3.17.0 """
 
 Declaration = Union['Location', List['Location']]
-""" The declaration of a symbol representation as one or many [locations](#Location). """
+""" The declaration of a symbol representation as one or many {@link Location locations}. """
 
 DeclarationLink = 'LocationLink'
 """ Information about where a symbol is declared.
 
-Provides additional metadata over normal [location](#Location) declarations, including the range of
+Provides additional metadata over normal {@link Location location} declarations, including the range of
 the declaring symbol.
 
 Servers should prefer returning `DeclarationLink` over `Declaration` if supported
@@ -616,14 +616,14 @@ pull request.
 
 PrepareRenameResult = Union['Range', '__PrepareRenameResult_Type_1', '__PrepareRenameResult_Type_2']
 
-ProgressToken = Union[int, str]
-
 DocumentSelector = List['DocumentFilter']
 """ A document selector is the combination of one or many document filters.
 
 @sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;
 
 The use of a string as a document filter is deprecated @since 3.16.0. """
+
+ProgressToken = Union[int, str]
 
 ChangeAnnotationIdentifier = str
 """ An identifier to refer to a change annotation stored with a workspace edit. """
@@ -657,6 +657,10 @@ a notebook cell document.
 
 @since 3.17.0 - proposed support for NotebookCellTextDocumentFilter. """
 
+LSPObject = Dict[str, 'LSPAny']
+""" LSP object definition.
+@since 3.17.0 """
+
 GlobPattern = Union['Pattern', 'RelativePattern']
 """ The glob pattern. Either a string pattern or a relative pattern.
 
@@ -664,8 +668,8 @@ GlobPattern = Union['Pattern', 'RelativePattern']
 
 TextDocumentFilter = Union['__TextDocumentFilter_Type_6', '__TextDocumentFilter_Type_7', '__TextDocumentFilter_Type_8']
 """ A document filter denotes a document by different properties like
-the [language](#TextDocument.languageId), the [scheme](#Uri.scheme) of
-its resource, or a glob-pattern that is applied to the [path](#TextDocument.fileName).
+the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
 
 Glob patterns can have the following syntax:
 - `*` to match one or more characters in a path segment
@@ -776,13 +780,6 @@ ConfigurationParams = TypedDict('ConfigurationParams', {
 """ The parameters of a configuration request. """
 
 
-PartialResultParams = TypedDict('PartialResultParams', {
-    # An optional token that a server can use to report partial results (e.g. streaming) to
-    # the client.
-    'partialResultToken': NotRequired['ProgressToken'],
-})
-
-
 DocumentColorParams = TypedDict('DocumentColorParams', {
     # The text document.
     'textDocument': 'TextDocumentIdentifier',
@@ -792,7 +789,7 @@ DocumentColorParams = TypedDict('DocumentColorParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [DocumentColorRequest](#DocumentColorRequest). """
+""" Parameters for a {@link DocumentColorRequest}. """
 
 
 ColorInformation = TypedDict('ColorInformation', {
@@ -827,7 +824,7 @@ ColorPresentationParams = TypedDict('ColorPresentationParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [ColorPresentationRequest](#ColorPresentationRequest). """
+""" Parameters for a {@link ColorPresentationRequest}. """
 
 
 ColorPresentation = TypedDict('ColorPresentation', {
@@ -835,12 +832,12 @@ ColorPresentation = TypedDict('ColorPresentation', {
     # picker header. By default this is also the text that is inserted when selecting
     # this color presentation.
     'label': str,
-    # An [edit](#TextEdit) which is applied to a document when selecting
-    # this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+    # An {@link TextEdit edit} which is applied to a document when selecting
+    # this presentation for the color.  When `falsy` the {@link ColorPresentation.label label}
     # is used.
     'textEdit': NotRequired['TextEdit'],
-    # An optional array of additional [text edits](#TextEdit) that are applied when
-    # selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+    # An optional array of additional {@link TextEdit text edits} that are applied when
+    # selecting this color presentation. Edits must not overlap with the main {@link ColorPresentation.textEdit edit} nor with themselves.
     'additionalTextEdits': NotRequired[List['TextEdit']],
 })
 
@@ -867,7 +864,7 @@ FoldingRangeParams = TypedDict('FoldingRangeParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [FoldingRangeRequest](#FoldingRangeRequest). """
+""" Parameters for a {@link FoldingRangeRequest}. """
 
 
 FoldingRange = TypedDict('FoldingRange', {
@@ -883,7 +880,7 @@ FoldingRange = TypedDict('FoldingRange', {
     'endCharacter': NotRequired[Uint],
     # Describes the kind of the folding range such as `comment' or 'region'. The kind
     # is used to categorize folding ranges and used by commands like 'Fold all comments'.
-    # See [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+    # See {@link FoldingRangeKind} for an enumeration of standardized kinds.
     'kind': NotRequired['FoldingRangeKind'],
     # The text that the client should show when the specified range is
     # collapsed. If not defined or not supported by the client, a default
@@ -944,7 +941,7 @@ SelectionRangeParams = TypedDict('SelectionRangeParams', {
 
 
 SelectionRange = TypedDict('SelectionRange', {
-    # The [range](#Range) of this selection range.
+    # The {@link Range range} of this selection range.
     'range': 'Range',
     # The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
     'parent': NotRequired['SelectionRange'],
@@ -1002,7 +999,7 @@ CallHierarchyItem = TypedDict('CallHierarchyItem', {
     # The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
     'range': 'Range',
     # The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.
-    # Must be contained by the [`range`](#CallHierarchyItem.range).
+    # Must be contained by the {@link CallHierarchyItem.range `range`}.
     'selectionRange': 'Range',
     # A data entry field that is preserved between a call hierarchy prepare and
     # incoming calls or outgoing calls requests.
@@ -1044,7 +1041,7 @@ CallHierarchyIncomingCall = TypedDict('CallHierarchyIncomingCall', {
     # The item that makes the call.
     'from': 'CallHierarchyItem',
     # The ranges at which the calls appear. This is relative to the caller
-    # denoted by [`this.from`](#CallHierarchyIncomingCall.from).
+    # denoted by {@link CallHierarchyIncomingCall.from `this.from`}.
     'fromRanges': List['Range'],
 })
 """ Represents an incoming call, e.g. a caller of a method or constructor.
@@ -1069,8 +1066,8 @@ CallHierarchyOutgoingCall = TypedDict('CallHierarchyOutgoingCall', {
     # The item that is called.
     'to': 'CallHierarchyItem',
     # The range at which this item is called. This is the range relative to the caller, e.g the item
-    # passed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)
-    # and not [`this.to`](#CallHierarchyOutgoingCall.to).
+    # passed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}
+    # and not {@link CallHierarchyOutgoingCall.to `this.to`}.
     'fromRanges': List['Range'],
 })
 """ Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
@@ -1376,7 +1373,7 @@ TypeHierarchyItem = TypedDict('TypeHierarchyItem', {
     'range': 'Range',
     # The range that should be selected and revealed when this symbol is being
     # picked, e.g. the name of a function. Must be contained by the
-    # [`range`](#TypeHierarchyItem.range).
+    # {@link TypeHierarchyItem.range `range`}.
     'selectionRange': 'Range',
     # A data entry field that is preserved between a type hierarchy prepare and
     # supertypes or subtypes requests. It could also be used to identify the
@@ -1719,7 +1716,7 @@ InitializeParams = TypedDict('InitializeParams', {
     # User provided initialization options.
     'initializationOptions': NotRequired['LSPAny'],
     # The initial trace setting. If omitted trace is disabled ('off').
-    'trace': NotRequired[Union[Literal['off'], Literal['messages'], Literal['compact'], Literal['verbose']]],
+    'trace': NotRequired['TraceValues'],
     # The workspace folders configured in the client when the server starts.
     #
     # This property is only available if the client supports workspace folders.
@@ -1968,15 +1965,15 @@ CompletionItem = TypedDict('CompletionItem', {
     # item of those that match best is selected.
     'preselect': NotRequired[bool],
     # A string that should be used when comparing this item
-    # with other items. When `falsy` the [label](#CompletionItem.label)
+    # with other items. When `falsy` the {@link CompletionItem.label label}
     # is used.
     'sortText': NotRequired[str],
     # A string that should be used when filtering a set of
-    # completion items. When `falsy` the [label](#CompletionItem.label)
+    # completion items. When `falsy` the {@link CompletionItem.label label}
     # is used.
     'filterText': NotRequired[str],
     # A string that should be inserted into a document when selecting
-    # this completion. When `falsy` the [label](#CompletionItem.label)
+    # this completion. When `falsy` the {@link CompletionItem.label label}
     # is used.
     #
     # The `insertText` is subject to interpretation by the client side.
@@ -2000,9 +1997,9 @@ CompletionItem = TypedDict('CompletionItem', {
     #
     # @since 3.16.0
     'insertTextMode': NotRequired['InsertTextMode'],
-    # An [edit](#TextEdit) which is applied to a document when selecting
+    # An {@link TextEdit edit} which is applied to a document when selecting
     # this completion. When an edit is provided the value of
-    # [insertText](#CompletionItem.insertText) is ignored.
+    # {@link CompletionItem.insertText insertText} is ignored.
     #
     # Most editors support two different operations when accepting a completion
     # item. One is to insert a completion text and the other is to replace an
@@ -2032,9 +2029,9 @@ CompletionItem = TypedDict('CompletionItem', {
     #
     # @since 3.17.0
     'textEditText': NotRequired[str],
-    # An optional array of additional [text edits](#TextEdit) that are applied when
+    # An optional array of additional {@link TextEdit text edits} that are applied when
     # selecting this completion. Edits must not overlap (including the same insert position)
-    # with the main [edit](#CompletionItem.textEdit) nor with themselves.
+    # with the main {@link CompletionItem.textEdit edit} nor with themselves.
     #
     # Additional text edits should be used to change text unrelated to the current cursor position
     # (for example adding an import statement at the top of the file if the completion item will
@@ -2044,12 +2041,12 @@ CompletionItem = TypedDict('CompletionItem', {
     # then type that character. *Note* that all commit characters should have `length=1` and that superfluous
     # characters will be ignored.
     'commitCharacters': NotRequired[List[str]],
-    # An optional [command](#Command) that is executed *after* inserting this completion. *Note* that
+    # An optional {@link Command command} that is executed *after* inserting this completion. *Note* that
     # additional modifications to the current document should be described with the
-    # [additionalTextEdits](#CompletionItem.additionalTextEdits)-property.
+    # {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
     'command': NotRequired['Command'],
     # A data entry field that is preserved on a completion item between a
-    # [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest).
+    # {@link CompletionRequest} and a {@link CompletionResolveRequest}.
     'data': NotRequired['LSPAny'],
 })
 """ A completion item represents a text snippet that is
@@ -2079,7 +2076,7 @@ CompletionList = TypedDict('CompletionList', {
     # The completion items.
     'items': List['CompletionItem'],
 })
-""" Represents a collection of [completion items](#CompletionItem) to be presented
+""" Represents a collection of {@link CompletionItem completion items} to be presented
 in the editor. """
 
 
@@ -2114,7 +2111,7 @@ CompletionRegistrationOptions = TypedDict('CompletionRegistrationOptions', {
     # @since 3.17.0
     'completionItem': NotRequired['__CompletionItem_Type_17'],
 })
-""" Registration options for a [CompletionRequest](#CompletionRequest). """
+""" Registration options for a {@link CompletionRequest}. """
 
 
 HoverParams = TypedDict('HoverParams', {
@@ -2125,7 +2122,7 @@ HoverParams = TypedDict('HoverParams', {
     # An optional token that a server can use to report work done progress.
     'workDoneToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [HoverRequest](#HoverRequest). """
+""" Parameters for a {@link HoverRequest}. """
 
 
 Hover = TypedDict('Hover', {
@@ -2143,7 +2140,7 @@ HoverRegistrationOptions = TypedDict('HoverRegistrationOptions', {
     # the document selector provided on the client side will be used.
     'documentSelector': Union['DocumentSelector', None],
 })
-""" Registration options for a [HoverRequest](#HoverRequest). """
+""" Registration options for a {@link HoverRequest}. """
 
 
 SignatureHelpParams = TypedDict('SignatureHelpParams', {
@@ -2159,7 +2156,7 @@ SignatureHelpParams = TypedDict('SignatureHelpParams', {
     # An optional token that a server can use to report work done progress.
     'workDoneToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [SignatureHelpRequest](#SignatureHelpRequest). """
+""" Parameters for a {@link SignatureHelpRequest}. """
 
 
 SignatureHelp = TypedDict('SignatureHelp', {
@@ -2203,7 +2200,7 @@ SignatureHelpRegistrationOptions = TypedDict('SignatureHelpRegistrationOptions',
     # @since 3.15.0
     'retriggerCharacters': NotRequired[List[str]],
 })
-""" Registration options for a [SignatureHelpRequest](#SignatureHelpRequest). """
+""" Registration options for a {@link SignatureHelpRequest}. """
 
 
 DefinitionParams = TypedDict('DefinitionParams', {
@@ -2217,7 +2214,7 @@ DefinitionParams = TypedDict('DefinitionParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [DefinitionRequest](#DefinitionRequest). """
+""" Parameters for a {@link DefinitionRequest}. """
 
 
 DefinitionRegistrationOptions = TypedDict('DefinitionRegistrationOptions', {
@@ -2225,7 +2222,7 @@ DefinitionRegistrationOptions = TypedDict('DefinitionRegistrationOptions', {
     # the document selector provided on the client side will be used.
     'documentSelector': Union['DocumentSelector', None],
 })
-""" Registration options for a [DefinitionRequest](#DefinitionRequest). """
+""" Registration options for a {@link DefinitionRequest}. """
 
 
 ReferenceParams = TypedDict('ReferenceParams', {
@@ -2240,7 +2237,7 @@ ReferenceParams = TypedDict('ReferenceParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [ReferencesRequest](#ReferencesRequest). """
+""" Parameters for a {@link ReferencesRequest}. """
 
 
 ReferenceRegistrationOptions = TypedDict('ReferenceRegistrationOptions', {
@@ -2248,7 +2245,7 @@ ReferenceRegistrationOptions = TypedDict('ReferenceRegistrationOptions', {
     # the document selector provided on the client side will be used.
     'documentSelector': Union['DocumentSelector', None],
 })
-""" Registration options for a [ReferencesRequest](#ReferencesRequest). """
+""" Registration options for a {@link ReferencesRequest}. """
 
 
 DocumentHighlightParams = TypedDict('DocumentHighlightParams', {
@@ -2262,13 +2259,13 @@ DocumentHighlightParams = TypedDict('DocumentHighlightParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+""" Parameters for a {@link DocumentHighlightRequest}. """
 
 
 DocumentHighlight = TypedDict('DocumentHighlight', {
     # The range this highlight applies to.
     'range': 'Range',
-    # The highlight kind, default is [text](#DocumentHighlightKind.Text).
+    # The highlight kind, default is {@link DocumentHighlightKind.Text text}.
     'kind': NotRequired['DocumentHighlightKind'],
 })
 """ A document highlight is a range inside a text document which deserves
@@ -2281,7 +2278,7 @@ DocumentHighlightRegistrationOptions = TypedDict('DocumentHighlightRegistrationO
     # the document selector provided on the client side will be used.
     'documentSelector': Union['DocumentSelector', None],
 })
-""" Registration options for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+""" Registration options for a {@link DocumentHighlightRequest}. """
 
 
 DocumentSymbolParams = TypedDict('DocumentSymbolParams', {
@@ -2293,7 +2290,7 @@ DocumentSymbolParams = TypedDict('DocumentSymbolParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" Parameters for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+""" Parameters for a {@link DocumentSymbolRequest}. """
 
 
 SymbolInformation = TypedDict('SymbolInformation', {
@@ -2371,7 +2368,7 @@ DocumentSymbolRegistrationOptions = TypedDict('DocumentSymbolRegistrationOptions
     # @since 3.16.0
     'label': NotRequired[str],
 })
-""" Registration options for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+""" Registration options for a {@link DocumentSymbolRequest}. """
 
 
 CodeActionParams = TypedDict('CodeActionParams', {
@@ -2387,7 +2384,7 @@ CodeActionParams = TypedDict('CodeActionParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [CodeActionRequest](#CodeActionRequest). """
+""" The parameters of a {@link CodeActionRequest}. """
 
 
 Command = TypedDict('Command', {
@@ -2471,7 +2468,7 @@ CodeActionRegistrationOptions = TypedDict('CodeActionRegistrationOptions', {
     # @since 3.16.0
     'resolveProvider': NotRequired[bool],
 })
-""" Registration options for a [CodeActionRequest](#CodeActionRequest). """
+""" Registration options for a {@link CodeActionRequest}. """
 
 
 WorkspaceSymbolParams = TypedDict('WorkspaceSymbolParams', {
@@ -2484,7 +2481,7 @@ WorkspaceSymbolParams = TypedDict('WorkspaceSymbolParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+""" The parameters of a {@link WorkspaceSymbolRequest}. """
 
 
 WorkspaceSymbol = TypedDict('WorkspaceSymbol', {
@@ -2525,7 +2522,7 @@ WorkspaceSymbolRegistrationOptions = TypedDict('WorkspaceSymbolRegistrationOptio
     # @since 3.17.0
     'resolveProvider': NotRequired[bool],
 })
-""" Registration options for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+""" Registration options for a {@link WorkspaceSymbolRequest}. """
 
 
 CodeLensParams = TypedDict('CodeLensParams', {
@@ -2537,7 +2534,7 @@ CodeLensParams = TypedDict('CodeLensParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [CodeLensRequest](#CodeLensRequest). """
+""" The parameters of a {@link CodeLensRequest}. """
 
 
 CodeLens = TypedDict('CodeLens', {
@@ -2546,11 +2543,11 @@ CodeLens = TypedDict('CodeLens', {
     # The command this code lens represents.
     'command': NotRequired['Command'],
     # A data entry field that is preserved on a code lens item between
-    # a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]
+    # a {@link CodeLensRequest} and a [CodeLensResolveRequest]
     # (#CodeLensResolveRequest)
     'data': NotRequired['LSPAny'],
 })
-""" A code lens represents a [command](#Command) that should be shown along with
+""" A code lens represents a {@link Command command} that should be shown along with
 source text, like the number of references, a way to run tests, etc.
 
 A code lens is _unresolved_ when no command is associated to it. For performance
@@ -2564,7 +2561,7 @@ CodeLensRegistrationOptions = TypedDict('CodeLensRegistrationOptions', {
     # Code lens has a resolve provider as well.
     'resolveProvider': NotRequired[bool],
 })
-""" Registration options for a [CodeLensRequest](#CodeLensRequest). """
+""" Registration options for a {@link CodeLensRequest}. """
 
 
 DocumentLinkParams = TypedDict('DocumentLinkParams', {
@@ -2576,7 +2573,7 @@ DocumentLinkParams = TypedDict('DocumentLinkParams', {
     # the client.
     'partialResultToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [DocumentLinkRequest](#DocumentLinkRequest). """
+""" The parameters of a {@link DocumentLinkRequest}. """
 
 
 DocumentLink = TypedDict('DocumentLink', {
@@ -2607,7 +2604,7 @@ DocumentLinkRegistrationOptions = TypedDict('DocumentLinkRegistrationOptions', {
     # Document links have a resolve provider as well.
     'resolveProvider': NotRequired[bool],
 })
-""" Registration options for a [DocumentLinkRequest](#DocumentLinkRequest). """
+""" Registration options for a {@link DocumentLinkRequest}. """
 
 
 DocumentFormattingParams = TypedDict('DocumentFormattingParams', {
@@ -2618,7 +2615,7 @@ DocumentFormattingParams = TypedDict('DocumentFormattingParams', {
     # An optional token that a server can use to report work done progress.
     'workDoneToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+""" The parameters of a {@link DocumentFormattingRequest}. """
 
 
 DocumentFormattingRegistrationOptions = TypedDict('DocumentFormattingRegistrationOptions', {
@@ -2626,7 +2623,7 @@ DocumentFormattingRegistrationOptions = TypedDict('DocumentFormattingRegistratio
     # the document selector provided on the client side will be used.
     'documentSelector': Union['DocumentSelector', None],
 })
-""" Registration options for a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+""" Registration options for a {@link DocumentFormattingRequest}. """
 
 
 DocumentRangeFormattingParams = TypedDict('DocumentRangeFormattingParams', {
@@ -2639,7 +2636,7 @@ DocumentRangeFormattingParams = TypedDict('DocumentRangeFormattingParams', {
     # An optional token that a server can use to report work done progress.
     'workDoneToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+""" The parameters of a {@link DocumentRangeFormattingRequest}. """
 
 
 DocumentRangeFormattingRegistrationOptions = TypedDict('DocumentRangeFormattingRegistrationOptions', {
@@ -2647,7 +2644,7 @@ DocumentRangeFormattingRegistrationOptions = TypedDict('DocumentRangeFormattingR
     # the document selector provided on the client side will be used.
     'documentSelector': Union['DocumentSelector', None],
 })
-""" Registration options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+""" Registration options for a {@link DocumentRangeFormattingRequest}. """
 
 
 DocumentOnTypeFormattingParams = TypedDict('DocumentOnTypeFormattingParams', {
@@ -2665,7 +2662,7 @@ DocumentOnTypeFormattingParams = TypedDict('DocumentOnTypeFormattingParams', {
     # The formatting options.
     'options': 'FormattingOptions',
 })
-""" The parameters of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+""" The parameters of a {@link DocumentOnTypeFormattingRequest}. """
 
 
 DocumentOnTypeFormattingRegistrationOptions = TypedDict('DocumentOnTypeFormattingRegistrationOptions', {
@@ -2677,7 +2674,7 @@ DocumentOnTypeFormattingRegistrationOptions = TypedDict('DocumentOnTypeFormattin
     # More trigger characters.
     'moreTriggerCharacter': NotRequired[List[str]],
 })
-""" Registration options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+""" Registration options for a {@link DocumentOnTypeFormattingRequest}. """
 
 
 RenameParams = TypedDict('RenameParams', {
@@ -2686,13 +2683,13 @@ RenameParams = TypedDict('RenameParams', {
     # The position at which this request was sent.
     'position': 'Position',
     # The new name of the symbol. If the given name is not valid the
-    # request must return a [ResponseError](#ResponseError) with an
+    # request must return a {@link ResponseError} with an
     # appropriate message set.
     'newName': str,
     # An optional token that a server can use to report work done progress.
     'workDoneToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [RenameRequest](#RenameRequest). """
+""" The parameters of a {@link RenameRequest}. """
 
 
 RenameRegistrationOptions = TypedDict('RenameRegistrationOptions', {
@@ -2704,7 +2701,7 @@ RenameRegistrationOptions = TypedDict('RenameRegistrationOptions', {
     # @since version 3.12.0
     'prepareProvider': NotRequired[bool],
 })
-""" Registration options for a [RenameRequest](#RenameRequest). """
+""" Registration options for a {@link RenameRequest}. """
 
 
 PrepareRenameParams = TypedDict('PrepareRenameParams', {
@@ -2725,14 +2722,14 @@ ExecuteCommandParams = TypedDict('ExecuteCommandParams', {
     # An optional token that a server can use to report work done progress.
     'workDoneToken': NotRequired['ProgressToken'],
 })
-""" The parameters of a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+""" The parameters of a {@link ExecuteCommandRequest}. """
 
 
 ExecuteCommandRegistrationOptions = TypedDict('ExecuteCommandRegistrationOptions', {
     # The commands to be executed on the server
     'commands': List[str],
 })
-""" Registration options for a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+""" Registration options for a {@link ExecuteCommandRequest}. """
 
 
 ApplyWorkspaceEditParams = TypedDict('ApplyWorkspaceEditParams', {
@@ -2862,6 +2859,13 @@ WorkDoneProgressParams = TypedDict('WorkDoneProgressParams', {
 })
 
 
+PartialResultParams = TypedDict('PartialResultParams', {
+    # An optional token that a server can use to report partial results (e.g. streaming) to
+    # the client.
+    'partialResultToken': NotRequired['ProgressToken'],
+})
+
+
 LocationLink = TypedDict('LocationLink', {
     # Span of the origin of this link.
     #
@@ -2878,7 +2882,7 @@ LocationLink = TypedDict('LocationLink', {
     # Must be contained by the `targetRange`. See also `DocumentSymbol#range`
     'targetSelectionRange': 'Range',
 })
-""" Represents the connection of two locations. Provides additional metadata over normal [locations](#Location),
+""" Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},
 including an origin range. """
 
 
@@ -3842,13 +3846,13 @@ SignatureHelpOptions = TypedDict('SignatureHelpOptions', {
     'retriggerCharacters': NotRequired[List[str]],
     'workDoneProgress': NotRequired[bool],
 })
-""" Server Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest). """
+""" Server Capabilities for a {@link SignatureHelpRequest}. """
 
 
 DefinitionOptions = TypedDict('DefinitionOptions', {
     'workDoneProgress': NotRequired[bool],
 })
-""" Server Capabilities for a [DefinitionRequest](#DefinitionRequest). """
+""" Server Capabilities for a {@link DefinitionRequest}. """
 
 
 ReferenceContext = TypedDict('ReferenceContext', {
@@ -3868,7 +3872,7 @@ ReferenceOptions = TypedDict('ReferenceOptions', {
 DocumentHighlightOptions = TypedDict('DocumentHighlightOptions', {
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+""" Provider options for a {@link DocumentHighlightRequest}. """
 
 
 BaseSymbolInformation = TypedDict('BaseSymbolInformation', {
@@ -3897,7 +3901,7 @@ DocumentSymbolOptions = TypedDict('DocumentSymbolOptions', {
     'label': NotRequired[str],
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+""" Provider options for a {@link DocumentSymbolRequest}. """
 
 
 CodeActionContext = TypedDict('CodeActionContext', {
@@ -3918,7 +3922,7 @@ CodeActionContext = TypedDict('CodeActionContext', {
     'triggerKind': NotRequired['CodeActionTriggerKind'],
 })
 """ Contains additional diagnostic information about the context in which
-a [code action](#CodeActionProvider.provideCodeActions) is run. """
+a {@link CodeActionProvider.provideCodeActions code action} is run. """
 
 
 CodeActionOptions = TypedDict('CodeActionOptions', {
@@ -3934,7 +3938,7 @@ CodeActionOptions = TypedDict('CodeActionOptions', {
     'resolveProvider': NotRequired[bool],
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [CodeActionRequest](#CodeActionRequest). """
+""" Provider options for a {@link CodeActionRequest}. """
 
 
 WorkspaceSymbolOptions = TypedDict('WorkspaceSymbolOptions', {
@@ -3945,7 +3949,7 @@ WorkspaceSymbolOptions = TypedDict('WorkspaceSymbolOptions', {
     'resolveProvider': NotRequired[bool],
     'workDoneProgress': NotRequired[bool],
 })
-""" Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+""" Server capabilities for a {@link WorkspaceSymbolRequest}. """
 
 
 CodeLensOptions = TypedDict('CodeLensOptions', {
@@ -3953,7 +3957,7 @@ CodeLensOptions = TypedDict('CodeLensOptions', {
     'resolveProvider': NotRequired[bool],
     'workDoneProgress': NotRequired[bool],
 })
-""" Code Lens provider options of a [CodeLensRequest](#CodeLensRequest). """
+""" Code Lens provider options of a {@link CodeLensRequest}. """
 
 
 DocumentLinkOptions = TypedDict('DocumentLinkOptions', {
@@ -3961,7 +3965,7 @@ DocumentLinkOptions = TypedDict('DocumentLinkOptions', {
     'resolveProvider': NotRequired[bool],
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [DocumentLinkRequest](#DocumentLinkRequest). """
+""" Provider options for a {@link DocumentLinkRequest}. """
 
 
 FormattingOptions = TypedDict('FormattingOptions', {
@@ -3988,13 +3992,13 @@ FormattingOptions = TypedDict('FormattingOptions', {
 DocumentFormattingOptions = TypedDict('DocumentFormattingOptions', {
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+""" Provider options for a {@link DocumentFormattingRequest}. """
 
 
 DocumentRangeFormattingOptions = TypedDict('DocumentRangeFormattingOptions', {
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+""" Provider options for a {@link DocumentRangeFormattingRequest}. """
 
 
 DocumentOnTypeFormattingOptions = TypedDict('DocumentOnTypeFormattingOptions', {
@@ -4003,7 +4007,7 @@ DocumentOnTypeFormattingOptions = TypedDict('DocumentOnTypeFormattingOptions', {
     # More trigger characters.
     'moreTriggerCharacter': NotRequired[List[str]],
 })
-""" Provider options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+""" Provider options for a {@link DocumentOnTypeFormattingRequest}. """
 
 
 RenameOptions = TypedDict('RenameOptions', {
@@ -4013,7 +4017,7 @@ RenameOptions = TypedDict('RenameOptions', {
     'prepareProvider': NotRequired[bool],
     'workDoneProgress': NotRequired[bool],
 })
-""" Provider options for a [RenameRequest](#RenameRequest). """
+""" Provider options for a {@link RenameRequest}. """
 
 
 ExecuteCommandOptions = TypedDict('ExecuteCommandOptions', {
@@ -4021,7 +4025,7 @@ ExecuteCommandOptions = TypedDict('ExecuteCommandOptions', {
     'commands': List[str],
     'workDoneProgress': NotRequired[bool],
 })
-""" The server capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+""" The server capabilities of a {@link ExecuteCommandRequest}. """
 
 
 SemanticTokensLegend = TypedDict('SemanticTokensLegend', {
@@ -4158,13 +4162,6 @@ WorkspaceUnchangedDocumentDiagnosticReport = TypedDict('WorkspaceUnchangedDocume
 })
 """ An unchanged document diagnostic report for a workspace diagnostic result.
 
-@since 3.17.0 """
-
-
-LSPObject = TypedDict('LSPObject', {
-
-})
-""" LSP object definition.
 @since 3.17.0 """
 
 
@@ -4694,14 +4691,14 @@ WorkspaceSymbolClientCapabilities = TypedDict('WorkspaceSymbolClientCapabilities
     # @since 3.17.0
     'resolveSupport': NotRequired['__ResolveSupport_Type_38'],
 })
-""" Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest). """
+""" Client capabilities for a {@link WorkspaceSymbolRequest}. """
 
 
 ExecuteCommandClientCapabilities = TypedDict('ExecuteCommandClientCapabilities', {
     # Execute command supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" The client capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest). """
+""" The client capabilities of a {@link ExecuteCommandRequest}. """
 
 
 SemanticTokensWorkspaceClientCapabilities = TypedDict('SemanticTokensWorkspaceClientCapabilities', {
@@ -4861,7 +4858,7 @@ SignatureHelpClientCapabilities = TypedDict('SignatureHelpClientCapabilities', {
     # @since 3.15.0
     'contextSupport': NotRequired[bool],
 })
-""" Client Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest). """
+""" Client Capabilities for a {@link SignatureHelpRequest}. """
 
 
 DeclarationClientCapabilities = TypedDict('DeclarationClientCapabilities', {
@@ -4883,7 +4880,7 @@ DefinitionClientCapabilities = TypedDict('DefinitionClientCapabilities', {
     # @since 3.14.0
     'linkSupport': NotRequired[bool],
 })
-""" Client Capabilities for a [DefinitionRequest](#DefinitionRequest). """
+""" Client Capabilities for a {@link DefinitionRequest}. """
 
 
 TypeDefinitionClientCapabilities = TypedDict('TypeDefinitionClientCapabilities', {
@@ -4916,14 +4913,14 @@ ReferenceClientCapabilities = TypedDict('ReferenceClientCapabilities', {
     # Whether references supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" Client Capabilities for a [ReferencesRequest](#ReferencesRequest). """
+""" Client Capabilities for a {@link ReferencesRequest}. """
 
 
 DocumentHighlightClientCapabilities = TypedDict('DocumentHighlightClientCapabilities', {
     # Whether document highlight supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" Client Capabilities for a [DocumentHighlightRequest](#DocumentHighlightRequest). """
+""" Client Capabilities for a {@link DocumentHighlightRequest}. """
 
 
 DocumentSymbolClientCapabilities = TypedDict('DocumentSymbolClientCapabilities', {
@@ -4946,7 +4943,7 @@ DocumentSymbolClientCapabilities = TypedDict('DocumentSymbolClientCapabilities',
     # @since 3.16.0
     'labelSupport': NotRequired[bool],
 })
-""" Client Capabilities for a [DocumentSymbolRequest](#DocumentSymbolRequest). """
+""" Client Capabilities for a {@link DocumentSymbolRequest}. """
 
 
 CodeActionClientCapabilities = TypedDict('CodeActionClientCapabilities', {
@@ -4986,14 +4983,14 @@ CodeActionClientCapabilities = TypedDict('CodeActionClientCapabilities', {
     # @since 3.16.0
     'honorsChangeAnnotations': NotRequired[bool],
 })
-""" The Client Capabilities of a [CodeActionRequest](#CodeActionRequest). """
+""" The Client Capabilities of a {@link CodeActionRequest}. """
 
 
 CodeLensClientCapabilities = TypedDict('CodeLensClientCapabilities', {
     # Whether code lens supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" The client capabilities  of a [CodeLensRequest](#CodeLensRequest). """
+""" The client capabilities  of a {@link CodeLensRequest}. """
 
 
 DocumentLinkClientCapabilities = TypedDict('DocumentLinkClientCapabilities', {
@@ -5004,7 +5001,7 @@ DocumentLinkClientCapabilities = TypedDict('DocumentLinkClientCapabilities', {
     # @since 3.15.0
     'tooltipSupport': NotRequired[bool],
 })
-""" The client capabilities of a [DocumentLinkRequest](#DocumentLinkRequest). """
+""" The client capabilities of a {@link DocumentLinkRequest}. """
 
 
 DocumentColorClientCapabilities = TypedDict('DocumentColorClientCapabilities', {
@@ -5019,21 +5016,21 @@ DocumentFormattingClientCapabilities = TypedDict('DocumentFormattingClientCapabi
     # Whether formatting supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" Client capabilities of a [DocumentFormattingRequest](#DocumentFormattingRequest). """
+""" Client capabilities of a {@link DocumentFormattingRequest}. """
 
 
 DocumentRangeFormattingClientCapabilities = TypedDict('DocumentRangeFormattingClientCapabilities', {
     # Whether range formatting supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" Client capabilities of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest). """
+""" Client capabilities of a {@link DocumentRangeFormattingRequest}. """
 
 
 DocumentOnTypeFormattingClientCapabilities = TypedDict('DocumentOnTypeFormattingClientCapabilities', {
     # Whether on type formatting supports dynamic registration.
     'dynamicRegistration': NotRequired[bool],
 })
-""" Client capabilities of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest). """
+""" Client capabilities of a {@link DocumentOnTypeFormattingRequest}. """
 
 
 RenameClientCapabilities = TypedDict('RenameClientCapabilities', {
@@ -5338,7 +5335,7 @@ __MarkedString_Type_5 = TypedDict('__MarkedString_Type_5', {
 __TextDocumentFilter_Type_6 = TypedDict('__TextDocumentFilter_Type_6', {
     # A language id, like `typescript`.
     'language': str,
-    # A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    # A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
     'scheme': NotRequired[str],
     # A glob pattern, like `*.{ts,js}`.
     'pattern': NotRequired[str],
@@ -5348,7 +5345,7 @@ __TextDocumentFilter_Type_6 = TypedDict('__TextDocumentFilter_Type_6', {
 __TextDocumentFilter_Type_7 = TypedDict('__TextDocumentFilter_Type_7', {
     # A language id, like `typescript`.
     'language': NotRequired[str],
-    # A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    # A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
     'scheme': str,
     # A glob pattern, like `*.{ts,js}`.
     'pattern': NotRequired[str],
@@ -5358,7 +5355,7 @@ __TextDocumentFilter_Type_7 = TypedDict('__TextDocumentFilter_Type_7', {
 __TextDocumentFilter_Type_8 = TypedDict('__TextDocumentFilter_Type_8', {
     # A language id, like `typescript`.
     'language': NotRequired[str],
-    # A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    # A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
     'scheme': NotRequired[str],
     # A glob pattern, like `*.{ts,js}`.
     'pattern': str,
@@ -5368,7 +5365,7 @@ __TextDocumentFilter_Type_8 = TypedDict('__TextDocumentFilter_Type_8', {
 __NotebookDocumentFilter_Type_9 = TypedDict('__NotebookDocumentFilter_Type_9', {
     # The type of the enclosing notebook.
     'notebookType': str,
-    # A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    # A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
     'scheme': NotRequired[str],
     # A glob pattern.
     'pattern': NotRequired[str],
@@ -5378,7 +5375,7 @@ __NotebookDocumentFilter_Type_9 = TypedDict('__NotebookDocumentFilter_Type_9', {
 __NotebookDocumentFilter_Type_10 = TypedDict('__NotebookDocumentFilter_Type_10', {
     # The type of the enclosing notebook.
     'notebookType': NotRequired[str],
-    # A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    # A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
     'scheme': str,
     # A glob pattern.
     'pattern': NotRequired[str],
@@ -5388,7 +5385,7 @@ __NotebookDocumentFilter_Type_10 = TypedDict('__NotebookDocumentFilter_Type_10',
 __NotebookDocumentFilter_Type_11 = TypedDict('__NotebookDocumentFilter_Type_11', {
     # The type of the enclosing notebook.
     'notebookType': NotRequired[str],
-    # A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    # A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
     'scheme': NotRequired[str],
     # A glob pattern.
     'pattern': str,

--- a/lsprotocol/lsp.json
+++ b/lsprotocol/lsp.json
@@ -53,7 +53,7 @@
 				"kind": "reference",
 				"name": "ImplementationRegistrationOptions"
 			},
-			"documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
 		},
 		{
 			"method": "textDocument/typeDefinition",
@@ -105,7 +105,7 @@
 				"kind": "reference",
 				"name": "TypeDefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
 		},
 		{
 			"method": "workspace/workspaceFolders",
@@ -139,17 +139,8 @@
 			},
 			"messageDirection": "serverToClient",
 			"params": {
-				"kind": "and",
-				"items": [
-					{
-						"kind": "reference",
-						"name": "ConfigurationParams"
-					},
-					{
-						"kind": "reference",
-						"name": "PartialResultParams"
-					}
-				]
+				"kind": "reference",
+				"name": "ConfigurationParams"
 			},
 			"documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model were the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
 		},
@@ -178,7 +169,7 @@
 				"kind": "reference",
 				"name": "DocumentColorRegistrationOptions"
 			},
-			"documentation": "A request to list all color symbols found in a given text document. The request's\nparameter is of type [DocumentColorParams](#DocumentColorParams) the\nresponse is of type [ColorInformation[]](#ColorInformation) or a Thenable\nthat resolves to such."
+			"documentation": "A request to list all color symbols found in a given text document. The request's\nparameter is of type {@link DocumentColorParams} the\nresponse is of type {@link ColorInformation ColorInformation[]} or a Thenable\nthat resolves to such."
 		},
 		{
 			"method": "textDocument/colorPresentation",
@@ -214,7 +205,7 @@
 					}
 				]
 			},
-			"documentation": "A request to list all presentation for a color. The request's\nparameter is of type [ColorPresentationParams](#ColorPresentationParams) the\nresponse is of type [ColorInformation[]](#ColorInformation) or a Thenable\nthat resolves to such."
+			"documentation": "A request to list all presentation for a color. The request's\nparameter is of type {@link ColorPresentationParams} the\nresponse is of type {@link ColorInformation ColorInformation[]} or a Thenable\nthat resolves to such."
 		},
 		{
 			"method": "textDocument/foldingRange",
@@ -250,7 +241,7 @@
 				"kind": "reference",
 				"name": "FoldingRangeRegistrationOptions"
 			},
-			"documentation": "A request to provide folding ranges in a document. The request's\nparameter is of type [FoldingRangeParams](#FoldingRangeParams), the\nresponse is of type [FoldingRangeList](#FoldingRangeList) or a Thenable\nthat resolves to such."
+			"documentation": "A request to provide folding ranges in a document. The request's\nparameter is of type {@link FoldingRangeParams}, the\nresponse is of type {@link FoldingRangeList} or a Thenable\nthat resolves to such."
 		},
 		{
 			"method": "textDocument/declaration",
@@ -302,7 +293,7 @@
 				"kind": "reference",
 				"name": "DeclarationRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Declaration](#Declaration)\nor a typed array of [DeclarationLink](#DeclarationLink) or a Thenable that resolves\nto such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Declaration}\nor a typed array of {@link DeclarationLink} or a Thenable that resolves\nto such."
 		},
 		{
 			"method": "textDocument/selectionRange",
@@ -338,7 +329,7 @@
 				"kind": "reference",
 				"name": "SelectionRangeRegistrationOptions"
 			},
-			"documentation": "A request to provide selection ranges in a document. The request's\nparameter is of type [SelectionRangeParams](#SelectionRangeParams), the\nresponse is of type [SelectionRange[]](#SelectionRange[]) or a Thenable\nthat resolves to such."
+			"documentation": "A request to provide selection ranges in a document. The request's\nparameter is of type {@link SelectionRangeParams}, the\nresponse is of type {@link SelectionRange SelectionRange[]} or a Thenable\nthat resolves to such."
 		},
 		{
 			"method": "window/workDoneProgress/create",
@@ -560,7 +551,7 @@
 				"kind": "base",
 				"name": "null"
 			},
-			"messageDirection": "clientToServer",
+			"messageDirection": "serverToClient",
 			"documentation": "@since 3.16.0",
 			"since": "3.16.0"
 		},
@@ -720,7 +711,7 @@
 				"kind": "reference",
 				"name": "MonikerRegistrationOptions"
 			},
-			"documentation": "A request to get the moniker of a symbol at a given text document position.\nThe request parameter is of type [TextDocumentPositionParams](#TextDocumentPositionParams).\nThe response is of type [Moniker[]](#Moniker[]) or `null`."
+			"documentation": "A request to get the moniker of a symbol at a given text document position.\nThe request parameter is of type {@link TextDocumentPositionParams}.\nThe response is of type {@link Moniker Moniker[]} or `null`."
 		},
 		{
 			"method": "textDocument/prepareTypeHierarchy",
@@ -852,7 +843,7 @@
 				"kind": "reference",
 				"name": "InlineValueRegistrationOptions"
 			},
-			"documentation": "A request to provide inline values in a document. The request's parameter is of\ntype [InlineValueParams](#InlineValueParams), the response is of type\n[InlineValue[]](#InlineValue[]) or a Thenable that resolves to such.\n\n@since 3.17.0",
+			"documentation": "A request to provide inline values in a document. The request's parameter is of\ntype {@link InlineValueParams}, the response is of type\n{@link InlineValue InlineValue[]} or a Thenable that resolves to such.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -861,7 +852,7 @@
 				"kind": "base",
 				"name": "null"
 			},
-			"messageDirection": "clientToServer",
+			"messageDirection": "serverToClient",
 			"documentation": "@since 3.17.0",
 			"since": "3.17.0"
 		},
@@ -899,7 +890,7 @@
 				"kind": "reference",
 				"name": "InlayHintRegistrationOptions"
 			},
-			"documentation": "A request to provide inlay hints in a document. The request's parameter is of\ntype [InlayHintsParams](#InlayHintsParams), the response is of type\n[InlayHint[]](#InlayHint[]) or a Thenable that resolves to such.\n\n@since 3.17.0",
+			"documentation": "A request to provide inlay hints in a document. The request's parameter is of\ntype {@link InlayHintsParams}, the response is of type\n{@link InlayHint InlayHint[]} or a Thenable that resolves to such.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -913,7 +904,7 @@
 				"kind": "reference",
 				"name": "InlayHint"
 			},
-			"documentation": "A request to resolve additional properties for an inlay hint.\nThe request's parameter is of type [InlayHint](#InlayHint), the response is\nof type [InlayHint](#InlayHint) or a Thenable that resolves to such.\n\n@since 3.17.0",
+			"documentation": "A request to resolve additional properties for an inlay hint.\nThe request's parameter is of type {@link InlayHint}, the response is\nof type {@link InlayHint} or a Thenable that resolves to such.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -922,7 +913,7 @@
 				"kind": "base",
 				"name": "null"
 			},
-			"messageDirection": "clientToServer",
+			"messageDirection": "serverToClient",
 			"documentation": "@since 3.17.0",
 			"since": "3.17.0"
 		},
@@ -980,7 +971,7 @@
 				"kind": "base",
 				"name": "null"
 			},
-			"messageDirection": "clientToServer",
+			"messageDirection": "serverToClient",
 			"documentation": "The diagnostic refresh request definition.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
@@ -1025,7 +1016,7 @@
 				"kind": "reference",
 				"name": "InitializeError"
 			},
-			"documentation": "The initialize request is sent from the client to the server.\nIt is sent once as the request after starting up the server.\nThe requests parameter is of type [InitializeParams](#InitializeParams)\nthe response if of type [InitializeResult](#InitializeResult) of a Thenable that\nresolves to such."
+			"documentation": "The initialize request is sent from the client to the server.\nIt is sent once as the request after starting up the server.\nThe requests parameter is of type {@link InitializeParams}\nthe response if of type {@link InitializeResult} of a Thenable that\nresolves to such."
 		},
 		{
 			"method": "shutdown",
@@ -1125,7 +1116,7 @@
 				"kind": "reference",
 				"name": "CompletionRegistrationOptions"
 			},
-			"documentation": "Request to request completion at a given text document position. The request's\nparameter is of type [TextDocumentPosition](#TextDocumentPosition) the response\nis of type [CompletionItem[]](#CompletionItem) or [CompletionList](#CompletionList)\nor a Thenable that resolves to such.\n\nThe request can delay the computation of the [`detail`](#CompletionItem.detail)\nand [`documentation`](#CompletionItem.documentation) properties to the `completionItem/resolve`\nrequest. However, properties that are needed for the initial sorting and filtering, like `sortText`,\n`filterText`, `insertText`, and `textEdit`, must not be changed during resolve."
+			"documentation": "Request to request completion at a given text document position. The request's\nparameter is of type {@link TextDocumentPosition} the response\nis of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}\nor a Thenable that resolves to such.\n\nThe request can delay the computation of the {@link CompletionItem.detail `detail`}\nand {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`\nrequest. However, properties that are needed for the initial sorting and filtering, like `sortText`,\n`filterText`, `insertText`, and `textEdit`, must not be changed during resolve."
 		},
 		{
 			"method": "completionItem/resolve",
@@ -1138,7 +1129,7 @@
 				"kind": "reference",
 				"name": "CompletionItem"
 			},
-			"documentation": "Request to resolve additional information for a given completion item.The request's\nparameter is of type [CompletionItem](#CompletionItem) the response\nis of type [CompletionItem](#CompletionItem) or a Thenable that resolves to such."
+			"documentation": "Request to resolve additional information for a given completion item.The request's\nparameter is of type {@link CompletionItem} the response\nis of type {@link CompletionItem} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/hover",
@@ -1164,7 +1155,7 @@
 				"kind": "reference",
 				"name": "HoverRegistrationOptions"
 			},
-			"documentation": "Request to request hover information at a given text document position. The request's\nparameter is of type [TextDocumentPosition](#TextDocumentPosition) the response is of\ntype [Hover](#Hover) or a Thenable that resolves to such."
+			"documentation": "Request to request hover information at a given text document position. The request's\nparameter is of type {@link TextDocumentPosition} the response is of\ntype {@link Hover} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/signatureHelp",
@@ -1241,7 +1232,7 @@
 				"kind": "reference",
 				"name": "DefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the response is of either type [Definition](#Definition)\nor a typed array of [DefinitionLink](#DefinitionLink) or a Thenable that resolves\nto such."
+			"documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the response is of either type {@link Definition}\nor a typed array of {@link DefinitionLink} or a Thenable that resolves\nto such."
 		},
 		{
 			"method": "textDocument/references",
@@ -1277,7 +1268,7 @@
 				"kind": "reference",
 				"name": "ReferenceRegistrationOptions"
 			},
-			"documentation": "A request to resolve project-wide references for the symbol denoted\nby the given text document position. The request's parameter is of\ntype [ReferenceParams](#ReferenceParams) the response is of type\n[Location[]](#Location) or a Thenable that resolves to such."
+			"documentation": "A request to resolve project-wide references for the symbol denoted\nby the given text document position. The request's parameter is of\ntype {@link ReferenceParams} the response is of type\n{@link Location Location[]} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/documentHighlight",
@@ -1313,7 +1304,7 @@
 				"kind": "reference",
 				"name": "DocumentHighlightRegistrationOptions"
 			},
-			"documentation": "Request to resolve a [DocumentHighlight](#DocumentHighlight) for a given\ntext document position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the request response is of type [DocumentHighlight[]]\n(#DocumentHighlight) or a Thenable that resolves to such."
+			"documentation": "Request to resolve a {@link DocumentHighlight} for a given\ntext document position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the request response is of type [DocumentHighlight[]]\n(#DocumentHighlight) or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/documentSymbol",
@@ -1368,7 +1359,7 @@
 				"kind": "reference",
 				"name": "DocumentSymbolRegistrationOptions"
 			},
-			"documentation": "A request to list all symbols found in a given text document. The request's\nparameter is of type [TextDocumentIdentifier](#TextDocumentIdentifier) the\nresponse is of type [SymbolInformation[]](#SymbolInformation) or a Thenable\nthat resolves to such."
+			"documentation": "A request to list all symbols found in a given text document. The request's\nparameter is of type {@link TextDocumentIdentifier} the\nresponse is of type {@link SymbolInformation SymbolInformation[]} or a Thenable\nthat resolves to such."
 		},
 		{
 			"method": "textDocument/codeAction",
@@ -1435,7 +1426,7 @@
 				"kind": "reference",
 				"name": "CodeAction"
 			},
-			"documentation": "Request to resolve additional information for a given code action.The request's\nparameter is of type [CodeAction](#CodeAction) the response\nis of type [CodeAction](#CodeAction) or a Thenable that resolves to such."
+			"documentation": "Request to resolve additional information for a given code action.The request's\nparameter is of type {@link CodeAction} the response\nis of type {@link CodeAction} or a Thenable that resolves to such."
 		},
 		{
 			"method": "workspace/symbol",
@@ -1490,7 +1481,7 @@
 				"kind": "reference",
 				"name": "WorkspaceSymbolRegistrationOptions"
 			},
-			"documentation": "A request to list project-wide symbols matching the query string given\nby the [WorkspaceSymbolParams](#WorkspaceSymbolParams). The response is\nof type [SymbolInformation[]](#SymbolInformation) or a Thenable that\nresolves to such.\n\n@since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients\n need to advertise support for WorkspaceSymbols via the client capability\n `workspace.symbol.resolveSupport`.\n",
+			"documentation": "A request to list project-wide symbols matching the query string given\nby the {@link WorkspaceSymbolParams}. The response is\nof type {@link SymbolInformation SymbolInformation[]} or a Thenable that\nresolves to such.\n\n@since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients\n need to advertise support for WorkspaceSymbols via the client capability\n `workspace.symbol.resolveSupport`.\n",
 			"since": "3.17.0 - support for WorkspaceSymbol in the returned data. Clients\nneed to advertise support for WorkspaceSymbols via the client capability\n`workspace.symbol.resolveSupport`."
 		},
 		{
@@ -1613,7 +1604,7 @@
 				"kind": "reference",
 				"name": "DocumentLink"
 			},
-			"documentation": "Request to resolve additional information for a given document link. The request's\nparameter is of type [DocumentLink](#DocumentLink) the response\nis of type [DocumentLink](#DocumentLink) or a Thenable that resolves to such."
+			"documentation": "Request to resolve additional information for a given document link. The request's\nparameter is of type {@link DocumentLink} the response\nis of type {@link DocumentLink} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/formatting",
@@ -2222,20 +2213,6 @@
 			"documentation": "The parameters of a configuration request."
 		},
 		{
-			"name": "PartialResultParams",
-			"properties": [
-				{
-					"name": "partialResultToken",
-					"type": {
-						"kind": "reference",
-						"name": "ProgressToken"
-					},
-					"optional": true,
-					"documentation": "An optional token that a server can use to report partial results (e.g. streaming) to\nthe client."
-				}
-			]
-		},
-		{
 			"name": "DocumentColorParams",
 			"properties": [
 				{
@@ -2257,7 +2234,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [DocumentColorRequest](#DocumentColorRequest)."
+			"documentation": "Parameters for a {@link DocumentColorRequest}."
 		},
 		{
 			"name": "ColorInformation",
@@ -2339,7 +2316,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [ColorPresentationRequest](#ColorPresentationRequest)."
+			"documentation": "Parameters for a {@link ColorPresentationRequest}."
 		},
 		{
 			"name": "ColorPresentation",
@@ -2359,7 +2336,7 @@
 						"name": "TextEdit"
 					},
 					"optional": true,
-					"documentation": "An [edit](#TextEdit) which is applied to a document when selecting\nthis presentation for the color.  When `falsy` the [label](#ColorPresentation.label)\nis used."
+					"documentation": "An {@link TextEdit edit} which is applied to a document when selecting\nthis presentation for the color.  When `falsy` the {@link ColorPresentation.label label}\nis used."
 				},
 				{
 					"name": "additionalTextEdits",
@@ -2371,7 +2348,7 @@
 						}
 					},
 					"optional": true,
-					"documentation": "An optional array of additional [text edits](#TextEdit) that are applied when\nselecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves."
+					"documentation": "An optional array of additional {@link TextEdit text edits} that are applied when\nselecting this color presentation. Edits must not overlap with the main {@link ColorPresentation.textEdit edit} nor with themselves."
 				}
 			]
 		},
@@ -2433,7 +2410,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [FoldingRangeRequest](#FoldingRangeRequest)."
+			"documentation": "Parameters for a {@link FoldingRangeRequest}."
 		},
 		{
 			"name": "FoldingRange",
@@ -2479,7 +2456,7 @@
 						"name": "FoldingRangeKind"
 					},
 					"optional": true,
-					"documentation": "Describes the kind of the folding range such as `comment' or 'region'. The kind\nis used to categorize folding ranges and used by commands like 'Fold all comments'.\nSee [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds."
+					"documentation": "Describes the kind of the folding range such as `comment' or 'region'. The kind\nis used to categorize folding ranges and used by commands like 'Fold all comments'.\nSee {@link FoldingRangeKind} for an enumeration of standardized kinds."
 				},
 				{
 					"name": "collapsedText",
@@ -2598,7 +2575,7 @@
 						"kind": "reference",
 						"name": "Range"
 					},
-					"documentation": "The [range](#Range) of this selection range."
+					"documentation": "The {@link Range range} of this selection range."
 				},
 				{
 					"name": "parent",
@@ -2738,7 +2715,7 @@
 						"kind": "reference",
 						"name": "Range"
 					},
-					"documentation": "The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.\nMust be contained by the [`range`](#CallHierarchyItem.range)."
+					"documentation": "The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.\nMust be contained by the {@link CallHierarchyItem.range `range`}."
 				},
 				{
 					"name": "data",
@@ -2819,7 +2796,7 @@
 							"name": "Range"
 						}
 					},
-					"documentation": "The ranges at which the calls appear. This is relative to the caller\ndenoted by [`this.from`](#CallHierarchyIncomingCall.from)."
+					"documentation": "The ranges at which the calls appear. This is relative to the caller\ndenoted by {@link CallHierarchyIncomingCall.from `this.from`}."
 				}
 			],
 			"documentation": "Represents an incoming call, e.g. a caller of a method or constructor.\n\n@since 3.16.0",
@@ -2869,7 +2846,7 @@
 							"name": "Range"
 						}
 					},
-					"documentation": "The range at which this item is called. This is the range relative to the caller, e.g the item\npassed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)\nand not [`this.to`](#CallHierarchyOutgoingCall.to)."
+					"documentation": "The range at which this item is called. This is the range relative to the caller, e.g the item\npassed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}\nand not {@link CallHierarchyOutgoingCall.to `this.to`}."
 				}
 			],
 			"documentation": "Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.\n\n@since 3.16.0",
@@ -3492,7 +3469,7 @@
 						"kind": "reference",
 						"name": "Range"
 					},
-					"documentation": "The range that should be selected and revealed when this symbol is being\npicked, e.g. the name of a function. Must be contained by the\n[`range`](#TypeHierarchyItem.range)."
+					"documentation": "The range that should be selected and revealed when this symbol is being\npicked, e.g. the name of a function. Must be contained by the\n{@link TypeHierarchyItem.range `range`}."
 				},
 				{
 					"name": "data",
@@ -4625,7 +4602,8 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Indicates if this item is deprecated.\n@deprecated Use `tags` instead."
+					"documentation": "Indicates if this item is deprecated.\n@deprecated Use `tags` instead.",
+					"deprecated": "Use `tags` instead."
 				},
 				{
 					"name": "preselect",
@@ -4643,7 +4621,7 @@
 						"name": "string"
 					},
 					"optional": true,
-					"documentation": "A string that should be used when comparing this item\nwith other items. When `falsy` the [label](#CompletionItem.label)\nis used."
+					"documentation": "A string that should be used when comparing this item\nwith other items. When `falsy` the {@link CompletionItem.label label}\nis used."
 				},
 				{
 					"name": "filterText",
@@ -4652,7 +4630,7 @@
 						"name": "string"
 					},
 					"optional": true,
-					"documentation": "A string that should be used when filtering a set of\ncompletion items. When `falsy` the [label](#CompletionItem.label)\nis used."
+					"documentation": "A string that should be used when filtering a set of\ncompletion items. When `falsy` the {@link CompletionItem.label label}\nis used."
 				},
 				{
 					"name": "insertText",
@@ -4661,7 +4639,7 @@
 						"name": "string"
 					},
 					"optional": true,
-					"documentation": "A string that should be inserted into a document when selecting\nthis completion. When `falsy` the [label](#CompletionItem.label)\nis used.\n\nThe `insertText` is subject to interpretation by the client side.\nSome tools might not take the string literally. For example\nVS Code when code complete is requested in this example\n`con<cursor position>` and a completion item with an `insertText` of\n`console` is provided it will only insert `sole`. Therefore it is\nrecommended to use `textEdit` instead since it avoids additional client\nside interpretation."
+					"documentation": "A string that should be inserted into a document when selecting\nthis completion. When `falsy` the {@link CompletionItem.label label}\nis used.\n\nThe `insertText` is subject to interpretation by the client side.\nSome tools might not take the string literally. For example\nVS Code when code complete is requested in this example\n`con<cursor position>` and a completion item with an `insertText` of\n`console` is provided it will only insert `sole`. Therefore it is\nrecommended to use `textEdit` instead since it avoids additional client\nside interpretation."
 				},
 				{
 					"name": "insertTextFormat",
@@ -4698,7 +4676,7 @@
 						]
 					},
 					"optional": true,
-					"documentation": "An [edit](#TextEdit) which is applied to a document when selecting\nthis completion. When an edit is provided the value of\n[insertText](#CompletionItem.insertText) is ignored.\n\nMost editors support two different operations when accepting a completion\nitem. One is to insert a completion text and the other is to replace an\nexisting text with a completion text. Since this can usually not be\npredetermined by a server it can report both ranges. Clients need to\nsignal support for `InsertReplaceEdits` via the\n`textDocument.completion.insertReplaceSupport` client capability\nproperty.\n\n*Note 1:* The text edit's range as well as both ranges from an insert\nreplace edit must be a [single line] and they must contain the position\nat which completion has been requested.\n*Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range\nmust be a prefix of the edit's replace range, that means it must be\ncontained and starting at the same position.\n\n@since 3.16.0 additional type `InsertReplaceEdit`",
+					"documentation": "An {@link TextEdit edit} which is applied to a document when selecting\nthis completion. When an edit is provided the value of\n{@link CompletionItem.insertText insertText} is ignored.\n\nMost editors support two different operations when accepting a completion\nitem. One is to insert a completion text and the other is to replace an\nexisting text with a completion text. Since this can usually not be\npredetermined by a server it can report both ranges. Clients need to\nsignal support for `InsertReplaceEdits` via the\n`textDocument.completion.insertReplaceSupport` client capability\nproperty.\n\n*Note 1:* The text edit's range as well as both ranges from an insert\nreplace edit must be a [single line] and they must contain the position\nat which completion has been requested.\n*Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range\nmust be a prefix of the edit's replace range, that means it must be\ncontained and starting at the same position.\n\n@since 3.16.0 additional type `InsertReplaceEdit`",
 					"since": "3.16.0 additional type `InsertReplaceEdit`"
 				},
 				{
@@ -4721,7 +4699,7 @@
 						}
 					},
 					"optional": true,
-					"documentation": "An optional array of additional [text edits](#TextEdit) that are applied when\nselecting this completion. Edits must not overlap (including the same insert position)\nwith the main [edit](#CompletionItem.textEdit) nor with themselves.\n\nAdditional text edits should be used to change text unrelated to the current cursor position\n(for example adding an import statement at the top of the file if the completion item will\ninsert an unqualified type)."
+					"documentation": "An optional array of additional {@link TextEdit text edits} that are applied when\nselecting this completion. Edits must not overlap (including the same insert position)\nwith the main {@link CompletionItem.textEdit edit} nor with themselves.\n\nAdditional text edits should be used to change text unrelated to the current cursor position\n(for example adding an import statement at the top of the file if the completion item will\ninsert an unqualified type)."
 				},
 				{
 					"name": "commitCharacters",
@@ -4742,7 +4720,7 @@
 						"name": "Command"
 					},
 					"optional": true,
-					"documentation": "An optional [command](#Command) that is executed *after* inserting this completion. *Note* that\nadditional modifications to the current document should be described with the\n[additionalTextEdits](#CompletionItem.additionalTextEdits)-property."
+					"documentation": "An optional {@link Command command} that is executed *after* inserting this completion. *Note* that\nadditional modifications to the current document should be described with the\n{@link CompletionItem.additionalTextEdits additionalTextEdits}-property."
 				},
 				{
 					"name": "data",
@@ -4751,7 +4729,7 @@
 						"name": "LSPAny"
 					},
 					"optional": true,
-					"documentation": "A data entry field that is preserved on a completion item between a\n[CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest)."
+					"documentation": "A data entry field that is preserved on a completion item between a\n{@link CompletionRequest} and a {@link CompletionResolveRequest}."
 				}
 			],
 			"documentation": "A completion item represents a text snippet that is\nproposed to complete text that is being typed."
@@ -4871,7 +4849,7 @@
 					"documentation": "The completion items."
 				}
 			],
-			"documentation": "Represents a collection of [completion items](#CompletionItem) to be presented\nin the editor."
+			"documentation": "Represents a collection of {@link CompletionItem completion items} to be presented\nin the editor."
 		},
 		{
 			"name": "CompletionRegistrationOptions",
@@ -4886,7 +4864,7 @@
 					"name": "CompletionOptions"
 				}
 			],
-			"documentation": "Registration options for a [CompletionRequest](#CompletionRequest)."
+			"documentation": "Registration options for a {@link CompletionRequest}."
 		},
 		{
 			"name": "HoverParams",
@@ -4903,7 +4881,7 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "Parameters for a [HoverRequest](#HoverRequest)."
+			"documentation": "Parameters for a {@link HoverRequest}."
 		},
 		{
 			"name": "Hover",
@@ -4957,7 +4935,7 @@
 					"name": "HoverOptions"
 				}
 			],
-			"documentation": "Registration options for a [HoverRequest](#HoverRequest)."
+			"documentation": "Registration options for a {@link HoverRequest}."
 		},
 		{
 			"name": "SignatureHelpParams",
@@ -4985,7 +4963,7 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "Parameters for a [SignatureHelpRequest](#SignatureHelpRequest)."
+			"documentation": "Parameters for a {@link SignatureHelpRequest}."
 		},
 		{
 			"name": "SignatureHelp",
@@ -5035,7 +5013,7 @@
 					"name": "SignatureHelpOptions"
 				}
 			],
-			"documentation": "Registration options for a [SignatureHelpRequest](#SignatureHelpRequest)."
+			"documentation": "Registration options for a {@link SignatureHelpRequest}."
 		},
 		{
 			"name": "DefinitionParams",
@@ -5056,7 +5034,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [DefinitionRequest](#DefinitionRequest)."
+			"documentation": "Parameters for a {@link DefinitionRequest}."
 		},
 		{
 			"name": "DefinitionRegistrationOptions",
@@ -5071,7 +5049,7 @@
 					"name": "DefinitionOptions"
 				}
 			],
-			"documentation": "Registration options for a [DefinitionRequest](#DefinitionRequest)."
+			"documentation": "Registration options for a {@link DefinitionRequest}."
 		},
 		{
 			"name": "ReferenceParams",
@@ -5100,7 +5078,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [ReferencesRequest](#ReferencesRequest)."
+			"documentation": "Parameters for a {@link ReferencesRequest}."
 		},
 		{
 			"name": "ReferenceRegistrationOptions",
@@ -5115,7 +5093,7 @@
 					"name": "ReferenceOptions"
 				}
 			],
-			"documentation": "Registration options for a [ReferencesRequest](#ReferencesRequest)."
+			"documentation": "Registration options for a {@link ReferencesRequest}."
 		},
 		{
 			"name": "DocumentHighlightParams",
@@ -5136,7 +5114,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+			"documentation": "Parameters for a {@link DocumentHighlightRequest}."
 		},
 		{
 			"name": "DocumentHighlight",
@@ -5156,7 +5134,7 @@
 						"name": "DocumentHighlightKind"
 					},
 					"optional": true,
-					"documentation": "The highlight kind, default is [text](#DocumentHighlightKind.Text)."
+					"documentation": "The highlight kind, default is {@link DocumentHighlightKind.Text text}."
 				}
 			],
 			"documentation": "A document highlight is a range inside a text document which deserves\nspecial attention. Usually a document highlight is visualized by changing\nthe background color of its range."
@@ -5174,7 +5152,7 @@
 					"name": "DocumentHighlightOptions"
 				}
 			],
-			"documentation": "Registration options for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+			"documentation": "Registration options for a {@link DocumentHighlightRequest}."
 		},
 		{
 			"name": "DocumentSymbolParams",
@@ -5198,7 +5176,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "Parameters for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+			"documentation": "Parameters for a {@link DocumentSymbolRequest}."
 		},
 		{
 			"name": "SymbolInformation",
@@ -5210,7 +5188,8 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead"
+					"documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead",
+					"deprecated": "Use tags instead"
 				},
 				{
 					"name": "location",
@@ -5277,7 +5256,8 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead"
+					"documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead",
+					"deprecated": "Use tags instead"
 				},
 				{
 					"name": "range",
@@ -5323,7 +5303,7 @@
 					"name": "DocumentSymbolOptions"
 				}
 			],
-			"documentation": "Registration options for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+			"documentation": "Registration options for a {@link DocumentSymbolRequest}."
 		},
 		{
 			"name": "CodeActionParams",
@@ -5363,7 +5343,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "The parameters of a [CodeActionRequest](#CodeActionRequest)."
+			"documentation": "The parameters of a {@link CodeActionRequest}."
 		},
 		{
 			"name": "Command",
@@ -5506,7 +5486,7 @@
 					"name": "CodeActionOptions"
 				}
 			],
-			"documentation": "Registration options for a [CodeActionRequest](#CodeActionRequest)."
+			"documentation": "Registration options for a {@link CodeActionRequest}."
 		},
 		{
 			"name": "WorkspaceSymbolParams",
@@ -5530,7 +5510,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+			"documentation": "The parameters of a {@link WorkspaceSymbolRequest}."
 		},
 		{
 			"name": "WorkspaceSymbol",
@@ -5590,7 +5570,7 @@
 					"name": "WorkspaceSymbolOptions"
 				}
 			],
-			"documentation": "Registration options for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+			"documentation": "Registration options for a {@link WorkspaceSymbolRequest}."
 		},
 		{
 			"name": "CodeLensParams",
@@ -5614,7 +5594,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "The parameters of a [CodeLensRequest](#CodeLensRequest)."
+			"documentation": "The parameters of a {@link CodeLensRequest}."
 		},
 		{
 			"name": "CodeLens",
@@ -5643,10 +5623,10 @@
 						"name": "LSPAny"
 					},
 					"optional": true,
-					"documentation": "A data entry field that is preserved on a code lens item between\na [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]\n(#CodeLensResolveRequest)"
+					"documentation": "A data entry field that is preserved on a code lens item between\na {@link CodeLensRequest} and a [CodeLensResolveRequest]\n(#CodeLensResolveRequest)"
 				}
 			],
-			"documentation": "A code lens represents a [command](#Command) that should be shown along with\nsource text, like the number of references, a way to run tests, etc.\n\nA code lens is _unresolved_ when no command is associated to it. For performance\nreasons the creation of a code lens and resolving should be done in two stages."
+			"documentation": "A code lens represents a {@link Command command} that should be shown along with\nsource text, like the number of references, a way to run tests, etc.\n\nA code lens is _unresolved_ when no command is associated to it. For performance\nreasons the creation of a code lens and resolving should be done in two stages."
 		},
 		{
 			"name": "CodeLensRegistrationOptions",
@@ -5661,7 +5641,7 @@
 					"name": "CodeLensOptions"
 				}
 			],
-			"documentation": "Registration options for a [CodeLensRequest](#CodeLensRequest)."
+			"documentation": "Registration options for a {@link CodeLensRequest}."
 		},
 		{
 			"name": "DocumentLinkParams",
@@ -5685,7 +5665,7 @@
 					"name": "PartialResultParams"
 				}
 			],
-			"documentation": "The parameters of a [DocumentLinkRequest](#DocumentLinkRequest)."
+			"documentation": "The parameters of a {@link DocumentLinkRequest}."
 		},
 		{
 			"name": "DocumentLink",
@@ -5742,7 +5722,7 @@
 					"name": "DocumentLinkOptions"
 				}
 			],
-			"documentation": "Registration options for a [DocumentLinkRequest](#DocumentLinkRequest)."
+			"documentation": "Registration options for a {@link DocumentLinkRequest}."
 		},
 		{
 			"name": "DocumentFormattingParams",
@@ -5770,7 +5750,7 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "The parameters of a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+			"documentation": "The parameters of a {@link DocumentFormattingRequest}."
 		},
 		{
 			"name": "DocumentFormattingRegistrationOptions",
@@ -5785,7 +5765,7 @@
 					"name": "DocumentFormattingOptions"
 				}
 			],
-			"documentation": "Registration options for a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+			"documentation": "Registration options for a {@link DocumentFormattingRequest}."
 		},
 		{
 			"name": "DocumentRangeFormattingParams",
@@ -5821,7 +5801,7 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "The parameters of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+			"documentation": "The parameters of a {@link DocumentRangeFormattingRequest}."
 		},
 		{
 			"name": "DocumentRangeFormattingRegistrationOptions",
@@ -5836,7 +5816,7 @@
 					"name": "DocumentRangeFormattingOptions"
 				}
 			],
-			"documentation": "Registration options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+			"documentation": "Registration options for a {@link DocumentRangeFormattingRequest}."
 		},
 		{
 			"name": "DocumentOnTypeFormattingParams",
@@ -5874,7 +5854,7 @@
 					"documentation": "The formatting options."
 				}
 			],
-			"documentation": "The parameters of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+			"documentation": "The parameters of a {@link DocumentOnTypeFormattingRequest}."
 		},
 		{
 			"name": "DocumentOnTypeFormattingRegistrationOptions",
@@ -5889,7 +5869,7 @@
 					"name": "DocumentOnTypeFormattingOptions"
 				}
 			],
-			"documentation": "Registration options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+			"documentation": "Registration options for a {@link DocumentOnTypeFormattingRequest}."
 		},
 		{
 			"name": "RenameParams",
@@ -5916,7 +5896,7 @@
 						"kind": "base",
 						"name": "string"
 					},
-					"documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a [ResponseError](#ResponseError) with an\nappropriate message set."
+					"documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a {@link ResponseError} with an\nappropriate message set."
 				}
 			],
 			"mixins": [
@@ -5925,7 +5905,7 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "The parameters of a [RenameRequest](#RenameRequest)."
+			"documentation": "The parameters of a {@link RenameRequest}."
 		},
 		{
 			"name": "RenameRegistrationOptions",
@@ -5940,7 +5920,7 @@
 					"name": "RenameOptions"
 				}
 			],
-			"documentation": "Registration options for a [RenameRequest](#RenameRequest)."
+			"documentation": "Registration options for a {@link RenameRequest}."
 		},
 		{
 			"name": "PrepareRenameParams",
@@ -5988,7 +5968,7 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "The parameters of a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+			"documentation": "The parameters of a {@link ExecuteCommandRequest}."
 		},
 		{
 			"name": "ExecuteCommandRegistrationOptions",
@@ -5999,7 +5979,7 @@
 					"name": "ExecuteCommandOptions"
 				}
 			],
-			"documentation": "Registration options for a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+			"documentation": "Registration options for a {@link ExecuteCommandRequest}."
 		},
 		{
 			"name": "ApplyWorkspaceEditParams",
@@ -6276,6 +6256,20 @@
 			]
 		},
 		{
+			"name": "PartialResultParams",
+			"properties": [
+				{
+					"name": "partialResultToken",
+					"type": {
+						"kind": "reference",
+						"name": "ProgressToken"
+					},
+					"optional": true,
+					"documentation": "An optional token that a server can use to report partial results (e.g. streaming) to\nthe client."
+				}
+			]
+		},
+		{
 			"name": "LocationLink",
 			"properties": [
 				{
@@ -6312,7 +6306,7 @@
 					"documentation": "The range that should be selected and revealed when this link is being followed, e.g the name of a function.\nMust be contained by the `targetRange`. See also `DocumentSymbol#range`"
 				}
 			],
-			"documentation": "Represents the connection of two locations. Provides additional metadata over normal [locations](#Location),\nincluding an origin range."
+			"documentation": "Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},\nincluding an origin range."
 		},
 		{
 			"name": "Range",
@@ -7729,7 +7723,8 @@
 						]
 					},
 					"optional": true,
-					"documentation": "The rootPath of the workspace. Is null\nif no folder is open.\n\n@deprecated in favour of rootUri."
+					"documentation": "The rootPath of the workspace. Is null\nif no folder is open.\n\n@deprecated in favour of rootUri.",
+					"deprecated": "in favour of rootUri."
 				},
 				{
 					"name": "rootUri",
@@ -7746,7 +7741,8 @@
 							}
 						]
 					},
-					"documentation": "The rootUri of the workspace. Is null if no\nfolder is open. If both `rootPath` and `rootUri` are set\n`rootUri` wins.\n\n@deprecated in favour of workspaceFolders."
+					"documentation": "The rootUri of the workspace. Is null if no\nfolder is open. If both `rootPath` and `rootUri` are set\n`rootUri` wins.\n\n@deprecated in favour of workspaceFolders.",
+					"deprecated": "in favour of workspaceFolders."
 				},
 				{
 					"name": "capabilities",
@@ -7768,25 +7764,8 @@
 				{
 					"name": "trace",
 					"type": {
-						"kind": "or",
-						"items": [
-							{
-								"kind": "stringLiteral",
-								"value": "off"
-							},
-							{
-								"kind": "stringLiteral",
-								"value": "messages"
-							},
-							{
-								"kind": "stringLiteral",
-								"value": "compact"
-							},
-							{
-								"kind": "stringLiteral",
-								"value": "verbose"
-							}
-						]
+						"kind": "reference",
+						"name": "TraceValues"
 					},
 					"optional": true,
 					"documentation": "The initial trace setting. If omitted trace is disabled ('off')."
@@ -8935,7 +8914,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Server Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest)."
+			"documentation": "Server Capabilities for a {@link SignatureHelpRequest}."
 		},
 		{
 			"name": "DefinitionOptions",
@@ -8946,7 +8925,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Server Capabilities for a [DefinitionRequest](#DefinitionRequest)."
+			"documentation": "Server Capabilities for a {@link DefinitionRequest}."
 		},
 		{
 			"name": "ReferenceContext",
@@ -8982,7 +8961,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+			"documentation": "Provider options for a {@link DocumentHighlightRequest}."
 		},
 		{
 			"name": "BaseSymbolInformation",
@@ -9048,7 +9027,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+			"documentation": "Provider options for a {@link DocumentSymbolRequest}."
 		},
 		{
 			"name": "CodeActionContext",
@@ -9087,7 +9066,7 @@
 					"since": "3.17.0"
 				}
 			],
-			"documentation": "Contains additional diagnostic information about the context in which\na [code action](#CodeActionProvider.provideCodeActions) is run."
+			"documentation": "Contains additional diagnostic information about the context in which\na {@link CodeActionProvider.provideCodeActions code action} is run."
 		},
 		{
 			"name": "CodeActionOptions",
@@ -9121,7 +9100,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [CodeActionRequest](#CodeActionRequest)."
+			"documentation": "Provider options for a {@link CodeActionRequest}."
 		},
 		{
 			"name": "WorkspaceSymbolOptions",
@@ -9143,7 +9122,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+			"documentation": "Server capabilities for a {@link WorkspaceSymbolRequest}."
 		},
 		{
 			"name": "CodeLensOptions",
@@ -9164,7 +9143,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Code Lens provider options of a [CodeLensRequest](#CodeLensRequest)."
+			"documentation": "Code Lens provider options of a {@link CodeLensRequest}."
 		},
 		{
 			"name": "DocumentLinkOptions",
@@ -9185,7 +9164,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [DocumentLinkRequest](#DocumentLinkRequest)."
+			"documentation": "Provider options for a {@link DocumentLinkRequest}."
 		},
 		{
 			"name": "FormattingOptions",
@@ -9248,7 +9227,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+			"documentation": "Provider options for a {@link DocumentFormattingRequest}."
 		},
 		{
 			"name": "DocumentRangeFormattingOptions",
@@ -9259,7 +9238,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+			"documentation": "Provider options for a {@link DocumentRangeFormattingRequest}."
 		},
 		{
 			"name": "DocumentOnTypeFormattingOptions",
@@ -9285,7 +9264,7 @@
 					"documentation": "More trigger characters."
 				}
 			],
-			"documentation": "Provider options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+			"documentation": "Provider options for a {@link DocumentOnTypeFormattingRequest}."
 		},
 		{
 			"name": "RenameOptions",
@@ -9307,7 +9286,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "Provider options for a [RenameRequest](#RenameRequest)."
+			"documentation": "Provider options for a {@link RenameRequest}."
 		},
 		{
 			"name": "ExecuteCommandOptions",
@@ -9330,7 +9309,7 @@
 					"name": "WorkDoneProgressOptions"
 				}
 			],
-			"documentation": "The server capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+			"documentation": "The server capabilities of a {@link ExecuteCommandRequest}."
 		},
 		{
 			"name": "SemanticTokensLegend",
@@ -9614,12 +9593,6 @@
 				}
 			],
 			"documentation": "An unchanged document diagnostic report for a workspace diagnostic result.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
-			"name": "LSPObject",
-			"properties": [],
-			"documentation": "LSP object definition.\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -10984,7 +10957,7 @@
 					"since": "3.17.0"
 				}
 			],
-			"documentation": "Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+			"documentation": "Client capabilities for a {@link WorkspaceSymbolRequest}."
 		},
 		{
 			"name": "ExecuteCommandClientCapabilities",
@@ -10999,7 +10972,7 @@
 					"documentation": "Execute command supports dynamic registration."
 				}
 			],
-			"documentation": "The client capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+			"documentation": "The client capabilities of a {@link ExecuteCommandRequest}."
 		},
 		{
 			"name": "SemanticTokensWorkspaceClientCapabilities",
@@ -11531,7 +11504,7 @@
 					"since": "3.15.0"
 				}
 			],
-			"documentation": "Client Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest)."
+			"documentation": "Client Capabilities for a {@link SignatureHelpRequest}."
 		},
 		{
 			"name": "DeclarationClientCapabilities",
@@ -11581,7 +11554,7 @@
 					"since": "3.14.0"
 				}
 			],
-			"documentation": "Client Capabilities for a [DefinitionRequest](#DefinitionRequest)."
+			"documentation": "Client Capabilities for a {@link DefinitionRequest}."
 		},
 		{
 			"name": "TypeDefinitionClientCapabilities",
@@ -11646,7 +11619,7 @@
 					"documentation": "Whether references supports dynamic registration."
 				}
 			],
-			"documentation": "Client Capabilities for a [ReferencesRequest](#ReferencesRequest)."
+			"documentation": "Client Capabilities for a {@link ReferencesRequest}."
 		},
 		{
 			"name": "DocumentHighlightClientCapabilities",
@@ -11661,7 +11634,7 @@
 					"documentation": "Whether document highlight supports dynamic registration."
 				}
 			],
-			"documentation": "Client Capabilities for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+			"documentation": "Client Capabilities for a {@link DocumentHighlightRequest}."
 		},
 		{
 			"name": "DocumentSymbolClientCapabilities",
@@ -11743,7 +11716,7 @@
 					"since": "3.16.0"
 				}
 			],
-			"documentation": "Client Capabilities for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+			"documentation": "Client Capabilities for a {@link DocumentSymbolRequest}."
 		},
 		{
 			"name": "CodeActionClientCapabilities",
@@ -11857,7 +11830,7 @@
 					"since": "3.16.0"
 				}
 			],
-			"documentation": "The Client Capabilities of a [CodeActionRequest](#CodeActionRequest)."
+			"documentation": "The Client Capabilities of a {@link CodeActionRequest}."
 		},
 		{
 			"name": "CodeLensClientCapabilities",
@@ -11872,7 +11845,7 @@
 					"documentation": "Whether code lens supports dynamic registration."
 				}
 			],
-			"documentation": "The client capabilities  of a [CodeLensRequest](#CodeLensRequest)."
+			"documentation": "The client capabilities  of a {@link CodeLensRequest}."
 		},
 		{
 			"name": "DocumentLinkClientCapabilities",
@@ -11897,7 +11870,7 @@
 					"since": "3.15.0"
 				}
 			],
-			"documentation": "The client capabilities of a [DocumentLinkRequest](#DocumentLinkRequest)."
+			"documentation": "The client capabilities of a {@link DocumentLinkRequest}."
 		},
 		{
 			"name": "DocumentColorClientCapabilities",
@@ -11926,7 +11899,7 @@
 					"documentation": "Whether formatting supports dynamic registration."
 				}
 			],
-			"documentation": "Client capabilities of a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+			"documentation": "Client capabilities of a {@link DocumentFormattingRequest}."
 		},
 		{
 			"name": "DocumentRangeFormattingClientCapabilities",
@@ -11941,7 +11914,7 @@
 					"documentation": "Whether range formatting supports dynamic registration."
 				}
 			],
-			"documentation": "Client capabilities of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+			"documentation": "Client capabilities of a {@link DocumentRangeFormattingRequest}."
 		},
 		{
 			"name": "DocumentOnTypeFormattingClientCapabilities",
@@ -11956,7 +11929,7 @@
 					"documentation": "Whether on type formatting supports dynamic registration."
 				}
 			],
-			"documentation": "Client capabilities of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+			"documentation": "Client capabilities of a {@link DocumentOnTypeFormattingRequest}."
 		},
 		{
 			"name": "RenameClientCapabilities",
@@ -13793,7 +13766,7 @@
 					}
 				]
 			},
-			"documentation": "The definition of a symbol represented as one or many [locations](#Location).\nFor most programming languages there is only one location at which a symbol is\ndefined.\n\nServers should prefer returning `DefinitionLink` over `Definition` if supported\nby the client."
+			"documentation": "The definition of a symbol represented as one or many {@link Location locations}.\nFor most programming languages there is only one location at which a symbol is\ndefined.\n\nServers should prefer returning `DefinitionLink` over `Definition` if supported\nby the client."
 		},
 		{
 			"name": "DefinitionLink",
@@ -13801,7 +13774,7 @@
 				"kind": "reference",
 				"name": "LocationLink"
 			},
-			"documentation": "Information about where a symbol is defined.\n\nProvides additional metadata over normal [location](#Location) definitions, including the range of\nthe defining symbol"
+			"documentation": "Information about where a symbol is defined.\n\nProvides additional metadata over normal {@link Location location} definitions, including the range of\nthe defining symbol"
 		},
 		{
 			"name": "LSPArray",
@@ -13875,7 +13848,7 @@
 					}
 				]
 			},
-			"documentation": "The declaration of a symbol representation as one or many [locations](#Location)."
+			"documentation": "The declaration of a symbol representation as one or many {@link Location locations}."
 		},
 		{
 			"name": "DeclarationLink",
@@ -13883,7 +13856,7 @@
 				"kind": "reference",
 				"name": "LocationLink"
 			},
-			"documentation": "Information about where a symbol is declared.\n\nProvides additional metadata over normal [location](#Location) declarations, including the range of\nthe declaring symbol.\n\nServers should prefer returning `DeclarationLink` over `Declaration` if supported\nby the client."
+			"documentation": "Information about where a symbol is declared.\n\nProvides additional metadata over normal {@link Location location} declarations, including the range of\nthe declaring symbol.\n\nServers should prefer returning `DeclarationLink` over `Declaration` if supported\nby the client."
 		},
 		{
 			"name": "InlineValue",
@@ -13973,6 +13946,18 @@
 			}
 		},
 		{
+			"name": "DocumentSelector",
+			"type": {
+				"kind": "array",
+				"element": {
+					"kind": "reference",
+					"name": "DocumentFilter"
+				}
+			},
+			"documentation": "A document selector is the combination of one or many document filters.\n\n@sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;\n\nThe use of a string as a document filter is deprecated @since 3.16.0.",
+			"since": "3.16.0."
+		},
+		{
 			"name": "ProgressToken",
 			"type": {
 				"kind": "or",
@@ -13987,18 +13972,6 @@
 					}
 				]
 			}
-		},
-		{
-			"name": "DocumentSelector",
-			"type": {
-				"kind": "array",
-				"element": {
-					"kind": "reference",
-					"name": "DocumentFilter"
-				}
-			},
-			"documentation": "A document selector is the combination of one or many document filters.\n\n@sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;\n\nThe use of a string as a document filter is deprecated @since 3.16.0.",
-			"since": "3.16.0."
 		},
 		{
 			"name": "ChangeAnnotationIdentifier",
@@ -14114,7 +14087,8 @@
 					}
 				]
 			},
-			"documentation": "MarkedString can be used to render human readable text. It is either a markdown string\nor a code-block that provides a language and a code snippet. The language identifier\nis semantically equal to the optional language identifier in fenced code blocks in GitHub\nissues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting\n\nThe pair of a language and a value is an equivalent to markdown:\n```${language}\n${value}\n```\n\nNote that markdown strings will be sanitized - that means html will be escaped.\n@deprecated use MarkupContent instead."
+			"documentation": "MarkedString can be used to render human readable text. It is either a markdown string\nor a code-block that provides a language and a code snippet. The language identifier\nis semantically equal to the optional language identifier in fenced code blocks in GitHub\nissues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting\n\nThe pair of a language and a value is an equivalent to markdown:\n```${language}\n${value}\n```\n\nNote that markdown strings will be sanitized - that means html will be escaped.\n@deprecated use MarkupContent instead.",
+			"deprecated": "use MarkupContent instead."
 		},
 		{
 			"name": "DocumentFilter",
@@ -14133,6 +14107,22 @@
 			},
 			"documentation": "A document filter describes a top level text document or\na notebook cell document.\n\n@since 3.17.0 - proposed support for NotebookCellTextDocumentFilter.",
 			"since": "3.17.0 - proposed support for NotebookCellTextDocumentFilter."
+		},
+		{
+			"name": "LSPObject",
+			"type": {
+				"kind": "map",
+				"key": {
+					"kind": "base",
+					"name": "string"
+				},
+				"value": {
+					"kind": "reference",
+					"name": "LSPAny"
+				}
+			},
+			"documentation": "LSP object definition.\n@since 3.17.0",
+			"since": "3.17.0"
 		},
 		{
 			"name": "GlobPattern",
@@ -14176,7 +14166,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
 								},
 								{
 									"name": "pattern",
@@ -14209,7 +14199,7 @@
 										"kind": "base",
 										"name": "string"
 									},
-									"documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
 								},
 								{
 									"name": "pattern",
@@ -14243,7 +14233,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
 								},
 								{
 									"name": "pattern",
@@ -14258,7 +14248,7 @@
 					}
 				]
 			},
-			"documentation": "A document filter denotes a document by different properties like\nthe [language](#TextDocument.languageId), the [scheme](#Uri.scheme) of\nits resource, or a glob-pattern that is applied to the [path](#TextDocument.fileName).\n\nGlob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
+			"documentation": "A document filter denotes a document by different properties like\nthe {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of\nits resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.\n\nGlob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -14285,7 +14275,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
 								},
 								{
 									"name": "pattern",
@@ -14318,7 +14308,7 @@
 										"kind": "base",
 										"name": "string"
 									},
-									"documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
 								},
 								{
 									"name": "pattern",
@@ -14352,7 +14342,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
 								},
 								{
 									"name": "pattern",

--- a/lsprotocol/lsp.schema.json
+++ b/lsprotocol/lsp.schema.json
@@ -94,6 +94,10 @@
       "additionalProperties": false,
       "description": "Defines an enumeration.",
       "properties": {
+        "deprecated": {
+          "description": "Whether the enumeration is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation.",
           "type": "string"
@@ -137,6 +141,10 @@
       "additionalProperties": false,
       "description": "Defines an enumeration entry.",
       "properties": {
+        "deprecated": {
+          "description": "Whether the enum entry is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation.",
           "type": "string"
@@ -340,6 +348,10 @@
       "additionalProperties": false,
       "description": "Represents a LSP notification",
       "properties": {
+        "deprecated": {
+          "description": "Whether the notification is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation;",
           "type": "string"
@@ -414,6 +426,10 @@
       "additionalProperties": false,
       "description": "Represents an object property.",
       "properties": {
+        "deprecated": {
+          "description": "Whether the property is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation.",
           "type": "string"
@@ -467,6 +483,10 @@
       "additionalProperties": false,
       "description": "Represents a LSP request",
       "properties": {
+        "deprecated": {
+          "description": "Whether the request is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation;",
           "type": "string"
@@ -551,6 +571,10 @@
       "additionalProperties": false,
       "description": "Defines the structure of an object literal.",
       "properties": {
+        "deprecated": {
+          "description": "Whether the structure is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation;",
           "type": "string"
@@ -599,6 +623,10 @@
       "additionalProperties": false,
       "description": "Defines a unnamed structure of an object literal.",
       "properties": {
+        "deprecated": {
+          "description": "Whether the literal is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation.",
           "type": "string"
@@ -704,6 +732,10 @@
       "additionalProperties": false,
       "description": "Defines a type alias. (e.g. `type Definition = Location | LocationLink`)",
       "properties": {
+        "deprecated": {
+          "description": "Whether the type alias is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
         "documentation": {
           "description": "An optional documentation.",
           "type": "string"


### PR DESCRIPTION
changes:
- Format for links changed from `"[location](#Location)"` to {@link Location location}. Pyright don't support the new format,
but the old one also didn't work as expected because it opened a blank browser window.

- Introduction of a new property "deprecated". I didn't implement the display for "deprecated", because we already display text that a property is being deprecated. Just search for the word "@deprecated" in lsp_types.py and you will see that we already display the deprecated text. If I were to implement it, which I did, but reverted, I saw duplicated text.

- they reordered some types. don't know why.

- some types changed, "ConfigurationParams"