### PR TITLE
Ensure all string enum values are comparable to strings

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -11,7 +11,19 @@ from utils.helpers import get_new_literal_structures, reset_new_literal_structur
 
 ENUM_OVERRIDES = {
     'CodeActionKind': 'StrEnum',
+    'DocumentDiagnosticReportKind': 'StrEnum',
+    'FailureHandlingKind': 'StrEnum',
+    'FileOperationPatternKind': 'StrEnum',
     'FoldingRangeKind': 'StrEnum',
+    'MarkupKind': 'StrEnum',
+    'MonikerKind': 'StrEnum',
+    'PositionEncodingKind': 'StrEnum',
+    'ResourceOperationKind': 'StrEnum',
+    'SemanticTokenModifiers': 'StrEnum',
+    'SemanticTokenTypes': 'StrEnum',
+    'TokenFormat': 'StrEnum',
+    'TraceValues': 'StrEnum',
+    'UniquenessLevel': 'StrEnum',
     'WatchKind': 'IntFlag',
 }  # type: Dict[str, Literal['StrEnum', 'IntFlag']]
 

--- a/generate.py
+++ b/generate.py
@@ -15,6 +15,7 @@ ENUM_OVERRIDES = {
     'FailureHandlingKind': 'StrEnum',
     'FileOperationPatternKind': 'StrEnum',
     'FoldingRangeKind': 'StrEnum',
+    'LanguageKind': 'StrEnum',
     'MarkupKind': 'StrEnum',
     'MonikerKind': 'StrEnum',
     'PositionEncodingKind': 'StrEnum',

--- a/lsp_types.py
+++ b/lsp_types.py
@@ -12,7 +12,7 @@ Uint = int
 RegExp = str
 
 
-class SemanticTokenTypes(Enum):
+class SemanticTokenTypes(StrEnum):
     """ A set of predefined token types. This set is not fixed
     an clients can specify additional token types via the
     corresponding client capabilities.
@@ -46,7 +46,7 @@ class SemanticTokenTypes(Enum):
     """ @since 3.17.0 """
 
 
-class SemanticTokenModifiers(Enum):
+class SemanticTokenModifiers(StrEnum):
     """ A set of predefined token modifiers. This set is not fixed
     an clients can specify additional token types via the
     corresponding client capabilities.
@@ -64,7 +64,7 @@ class SemanticTokenModifiers(Enum):
     DefaultLibrary = 'defaultLibrary'
 
 
-class DocumentDiagnosticReportKind(Enum):
+class DocumentDiagnosticReportKind(StrEnum):
     """ The document diagnostic report kinds.
 
     @since 3.17.0 """
@@ -165,7 +165,7 @@ class SymbolTag(IntEnum):
     """ Render a symbol as obsolete, usually using a strike-out. """
 
 
-class UniquenessLevel(Enum):
+class UniquenessLevel(StrEnum):
     """ Moniker uniqueness level to define scope of the moniker.
 
     @since 3.16.0 """
@@ -181,7 +181,7 @@ class UniquenessLevel(Enum):
     """ The moniker is globally unique """
 
 
-class MonikerKind(Enum):
+class MonikerKind(StrEnum):
     """ The moniker kind.
 
     @since 3.16.0 """
@@ -405,7 +405,7 @@ class TraceValue(Enum):
     """ Verbose message tracing. """
 
 
-class MarkupKind(Enum):
+class MarkupKind(StrEnum):
     """ Describes the content type that a client supports in various
     result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
 
@@ -417,7 +417,7 @@ class MarkupKind(Enum):
     """ Markdown is supported as a content format """
 
 
-class LanguageKind(Enum):
+class LanguageKind(StrEnum):
     """ Predefined Language kinds
     @since 3.18.0
     @proposed """
@@ -500,7 +500,7 @@ class InlineCompletionTriggerKind(IntEnum):
     """ Completion was triggered automatically while editing. """
 
 
-class PositionEncodingKind(Enum):
+class PositionEncodingKind(StrEnum):
     """ A set of predefined position encoding kinds.
 
     @since 3.17.0 """
@@ -602,7 +602,7 @@ class CodeActionTriggerKind(IntEnum):
     also be triggered when file content changes. """
 
 
-class FileOperationPatternKind(Enum):
+class FileOperationPatternKind(StrEnum):
     """ A pattern kind describing if a glob pattern matches a file a folder or
     both.
 
@@ -623,7 +623,7 @@ class NotebookCellKind(IntEnum):
     """ A code-cell is source code. """
 
 
-class ResourceOperationKind(Enum):
+class ResourceOperationKind(StrEnum):
     Create = 'create'
     """ Supports creating new files and folders. """
     Rename = 'rename'
@@ -632,7 +632,7 @@ class ResourceOperationKind(Enum):
     """ Supports deleting existing files and folders. """
 
 
-class FailureHandlingKind(Enum):
+class FailureHandlingKind(StrEnum):
     Abort = 'abort'
     """ Applying the workspace change is simply aborted if one of the changes provided
     fails. All operations executed before the failing operation stay executed. """
@@ -654,7 +654,7 @@ class PrepareSupportDefaultBehavior(IntEnum):
     according the to language's syntax rule. """
 
 
-class TokenFormat(Enum):
+class TokenFormat(StrEnum):
     Relative = 'relative'
 
 

--- a/lsp_types.py
+++ b/lsp_types.py
@@ -5850,4 +5850,3 @@ class ClientSemanticTokensRequestFullDelta(TypedDict):
     delta: NotRequired[bool]
     """ The client will send the `textDocument/semanticTokens/full/delta` request if
     the server provides a corresponding handler. """
-

--- a/lsp_types_sublime_text_33.py
+++ b/lsp_types_sublime_text_33.py
@@ -12,7 +12,7 @@ Uint = int
 RegExp = str
 
 
-class SemanticTokenTypes(Enum):
+class SemanticTokenTypes(StrEnum):
     """ A set of predefined token types. This set is not fixed
     an clients can specify additional token types via the
     corresponding client capabilities.
@@ -46,7 +46,7 @@ class SemanticTokenTypes(Enum):
     """ @since 3.17.0 """
 
 
-class SemanticTokenModifiers(Enum):
+class SemanticTokenModifiers(StrEnum):
     """ A set of predefined token modifiers. This set is not fixed
     an clients can specify additional token types via the
     corresponding client capabilities.
@@ -64,7 +64,7 @@ class SemanticTokenModifiers(Enum):
     DefaultLibrary = 'defaultLibrary'
 
 
-class DocumentDiagnosticReportKind(Enum):
+class DocumentDiagnosticReportKind(StrEnum):
     """ The document diagnostic report kinds.
 
     @since 3.17.0 """
@@ -165,7 +165,7 @@ class SymbolTag(IntEnum):
     """ Render a symbol as obsolete, usually using a strike-out. """
 
 
-class UniquenessLevel(Enum):
+class UniquenessLevel(StrEnum):
     """ Moniker uniqueness level to define scope of the moniker.
 
     @since 3.16.0 """
@@ -181,7 +181,7 @@ class UniquenessLevel(Enum):
     """ The moniker is globally unique """
 
 
-class MonikerKind(Enum):
+class MonikerKind(StrEnum):
     """ The moniker kind.
 
     @since 3.16.0 """
@@ -405,7 +405,7 @@ class TraceValue(Enum):
     """ Verbose message tracing. """
 
 
-class MarkupKind(Enum):
+class MarkupKind(StrEnum):
     """ Describes the content type that a client supports in various
     result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
 
@@ -417,7 +417,7 @@ class MarkupKind(Enum):
     """ Markdown is supported as a content format """
 
 
-class LanguageKind(Enum):
+class LanguageKind(StrEnum):
     """ Predefined Language kinds
     @since 3.18.0
     @proposed """
@@ -500,7 +500,7 @@ class InlineCompletionTriggerKind(IntEnum):
     """ Completion was triggered automatically while editing. """
 
 
-class PositionEncodingKind(Enum):
+class PositionEncodingKind(StrEnum):
     """ A set of predefined position encoding kinds.
 
     @since 3.17.0 """
@@ -602,7 +602,7 @@ class CodeActionTriggerKind(IntEnum):
     also be triggered when file content changes. """
 
 
-class FileOperationPatternKind(Enum):
+class FileOperationPatternKind(StrEnum):
     """ A pattern kind describing if a glob pattern matches a file a folder or
     both.
 
@@ -623,7 +623,7 @@ class NotebookCellKind(IntEnum):
     """ A code-cell is source code. """
 
 
-class ResourceOperationKind(Enum):
+class ResourceOperationKind(StrEnum):
     Create = 'create'
     """ Supports creating new files and folders. """
     Rename = 'rename'
@@ -632,7 +632,7 @@ class ResourceOperationKind(Enum):
     """ Supports deleting existing files and folders. """
 
 
-class FailureHandlingKind(Enum):
+class FailureHandlingKind(StrEnum):
     Abort = 'abort'
     """ Applying the workspace change is simply aborted if one of the changes provided
     fails. All operations executed before the failing operation stay executed. """
@@ -654,7 +654,7 @@ class PrepareSupportDefaultBehavior(IntEnum):
     according the to language's syntax rule. """
 
 
-class TokenFormat(Enum):
+class TokenFormat(StrEnum):
     Relative = 'relative'
 
 

--- a/lsp_types_sublime_text_33.py
+++ b/lsp_types_sublime_text_33.py
@@ -6221,4 +6221,3 @@ ClientSemanticTokensRequestFullDelta = TypedDict('ClientSemanticTokensRequestFul
 })
 """ @since 3.18.0
 @proposed """
-


### PR DESCRIPTION
This is part of a workaround for a problem described at https://github.com/sublimelsp/LSP/pull/2446#issuecomment-2059553794

Currently it would not work on Python 3.8 to import directly from `enum`, because most of the enums with string values are just regular `Enum` instead of `StrEnum`. This means we can't compare values to the strings from a server response. But if they are `StrEnum`, they could be compared directly (in theory, because StrEnum is not part of Python 3.8 - but this means that the enums inherit from our fake StrEnum class, instead of to the real Enum class from the enum module).

I think then it should work, together with another small change I have in mind.