### PR TITLE
Generate 3.18.0 types

### DIFF
--- a/download_schemas.py
+++ b/download_schemas.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.request import urlopen
 
-REPO_URL = 'https://raw.githubusercontent.com/microsoft/vscode-languageserver-node'
+REPO_URL = 'https://raw.githubusercontent.com/microsoft/language-server-protocol'
 
-with urlopen(f'{REPO_URL}/main/protocol/metaModel.schema.json') as url:
+with urlopen(f'{REPO_URL}/refs/heads/gh-pages/_specifications/lsp/3.18/metaModel/metaModel.schema.json') as url:
     Path('./lsprotocol/lsp.schema.json').write_text(url.read().decode('utf-8'))
 
-with urlopen(f'{REPO_URL}/main/protocol/metaModel.json') as url:
+with urlopen(f'{REPO_URL}/refs/heads/gh-pages/_specifications/lsp/3.18/metaModel/metaModel.json') as url:
     Path('./lsprotocol/lsp.json').write_text(url.read().decode('utf-8'))

--- a/generated/custom.py
+++ b/generated/custom.py
@@ -478,7 +478,7 @@ class CodeLensResolveResponse(TypedDict):
 
 class ColorPresentationResponse(TypedDict):
     method: Literal['textDocument/colorPresentation']
-    result: List['ColorPresentation']
+    result: Union[List['ColorPresentation'], None]
 
 
 class CompletionResponse(TypedDict):
@@ -513,7 +513,7 @@ class DiagnosticRefreshResponse(TypedDict):
 
 class DocumentColorResponse(TypedDict):
     method: Literal['textDocument/documentColor']
-    result: List['ColorInformation']
+    result: Union[List['ColorInformation'], None]
 
 
 class DocumentDiagnosticResponse(TypedDict):

--- a/generated/lsp_types.py
+++ b/generated/lsp_types.py
@@ -1,6 +1,6 @@
 # ruff: noqa: E501, UP006, UP007
 # Code generated. DO NOT EDIT.
-# LSP v3.17.0
+# LSP v3.18.0
 
 from __future__ import annotations
 
@@ -3706,16 +3706,16 @@ class DocumentOnTypeFormattingRegistrationOptions(TypedDict):
 class RenameParams(TypedDict):
     """The parameters of a {@link RenameRequest}."""
 
-    textDocument: 'TextDocumentIdentifier'
-    """The document to rename."""
-    position: 'Position'
-    """The position at which this request was sent."""
     newName: str
     """
     The new name of the symbol. If the given name is not valid the
     request must return a {@link ResponseError} with an
     appropriate message set.
     """
+    textDocument: 'TextDocumentIdentifier'
+    """The text document."""
+    position: 'Position'
+    """The position inside the text document."""
     workDoneToken: NotRequired['ProgressToken']
     """An optional token that a server can use to report work done progress."""
 
@@ -5024,8 +5024,12 @@ class Diagnostic(TypedDict):
     diagnostic, e.g. 'typescript' or 'super lint'. It usually
     appears in the user interface.
     """
-    message: str
-    """The diagnostic's message. It usually appears in the user interface"""
+    message: Union[str, 'MarkupContent']
+    """
+    The diagnostic's message. It usually appears in the user interface.
+
+    @since 3.18.0 - support for `MarkupContent`. This is guarded by the client capability `textDocument.diagnostic.markupMessageSupport`.
+    """
     tags: NotRequired[List['DiagnosticTag']]
     """
     Additional metadata about the diagnostic.

--- a/lsprotocol/lsp.json
+++ b/lsprotocol/lsp.json
@@ -1,6 +1,6 @@
 {
 	"metaData": {
-		"version": "3.17.0"
+		"version": "3.18.0"
 	},
 	"requests": [
 		{
@@ -159,11 +159,20 @@
 			"method": "textDocument/documentColor",
 			"typeName": "DocumentColorRequest",
 			"result": {
-				"kind": "array",
-				"element": {
-					"kind": "reference",
-					"name": "ColorInformation"
-				}
+				"kind": "or",
+				"items": [
+					{
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "ColorInformation"
+						}
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
 			},
 			"messageDirection": "clientToServer",
 			"clientCapability": "textDocument.colorProvider",
@@ -189,13 +198,24 @@
 			"method": "textDocument/colorPresentation",
 			"typeName": "ColorPresentationRequest",
 			"result": {
-				"kind": "array",
-				"element": {
-					"kind": "reference",
-					"name": "ColorPresentation"
-				}
+				"kind": "or",
+				"items": [
+					{
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "ColorPresentation"
+						}
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.colorProvider",
+			"serverCapability": "colorProvider",
 			"params": {
 				"kind": "reference",
 				"name": "ColorPresentationParams"
@@ -436,6 +456,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyIncomingCallsParams"
@@ -470,6 +492,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyOutgoingCallsParams"
@@ -1898,6 +1922,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.rangeFormatting",
+			"serverCapability": "documentRangeFormattingProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentRangeFormattingParams"
@@ -1928,8 +1954,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
-			"clientCapability": "textDocument.rangeFormatting",
-			"serverCapability": "documentRangeFormattingProvider",
+			"clientCapability": "textDocument.rangeFormatting.rangesSupport",
+			"serverCapability": "documentRangeFormattingProvider.rangesSupport",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentRangesFormattingParams"
@@ -2276,7 +2302,7 @@
 			"typeName": "DidOpenTextDocumentNotification",
 			"messageDirection": "clientToServer",
 			"clientCapability": "textDocument.synchronization",
-			"serverCapability": "textDocumentSync",
+			"serverCapability": "textDocumentSync.openClose",
 			"params": {
 				"kind": "reference",
 				"name": "DidOpenTextDocumentParams"
@@ -2308,7 +2334,7 @@
 			"typeName": "DidCloseTextDocumentNotification",
 			"messageDirection": "clientToServer",
 			"clientCapability": "textDocument.synchronization",
-			"serverCapability": "textDocumentSync",
+			"serverCapability": "textDocumentSync.openClose",
 			"params": {
 				"kind": "reference",
 				"name": "DidCloseTextDocumentParams"
@@ -6398,28 +6424,18 @@
 			"name": "RenameParams",
 			"properties": [
 				{
-					"name": "textDocument",
-					"type": {
-						"kind": "reference",
-						"name": "TextDocumentIdentifier"
-					},
-					"documentation": "The document to rename."
-				},
-				{
-					"name": "position",
-					"type": {
-						"kind": "reference",
-						"name": "Position"
-					},
-					"documentation": "The position at which this request was sent."
-				},
-				{
 					"name": "newName",
 					"type": {
 						"kind": "base",
 						"name": "string"
 					},
 					"documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a {@link ResponseError} with an\nappropriate message set."
+				}
+			],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "TextDocumentPositionParams"
 				}
 			],
 			"mixins": [
@@ -9143,10 +9159,19 @@
 				{
 					"name": "message",
 					"type": {
-						"kind": "base",
-						"name": "string"
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "reference",
+								"name": "MarkupContent"
+							}
+						]
 					},
-					"documentation": "The diagnostic's message. It usually appears in the user interface"
+					"documentation": "The diagnostic's message. It usually appears in the user interface.\n\n@since 3.18.0 - support for `MarkupContent`. This is guarded by the client capability `textDocument.diagnostic.markupMessageSupport`."
 				},
 				{
 					"name": "tags",


### PR DESCRIPTION
This PR brings 3.18 LSP types.

I had the false impression that the latest changes to metaModel.json file are done at microsoft/vscode-languageserver-node, but actually the latest chnages are done at microsoft/language-server-protocol, 
so I updated the download script to point to microsoft/language-server-protocol

I also manually edited lsp.json to add diagnostic message union string MarkupContent
until they fix it upstream.

As Janos noticed they have added the type in https://github.com/microsoft/language-server-protocol/commit/df7c77baf1ba36ba1243d57d9fc9e9985fe76bbf
and later removed it in https://github.com/microsoft/language-server-protocol/commit/7e1b69da6aa6460b2041b309dde6aa95b39b8a4d (I [have asked them](https://github.com/microsoft/language-server-protocol/commit/7e1b69da6aa6460b2041b309dde6aa95b39b8a4d#r181468341) if this was a mistake)