### PR TITLE
Add params to ClientResponse

### DIFF
--- a/generated/custom.py
+++ b/generated/custom.py
@@ -433,6 +433,7 @@ ServerRequest: TypeAlias = Union[
 
 class ApplyWorkspaceEditResponse(TypedDict):
     method: Literal['workspace/applyEdit']
+    params: 'ApplyWorkspaceEditParams'
     result: 'ApplyWorkspaceEditResult'
 
 
@@ -463,6 +464,7 @@ class CodeActionResolveResponse(TypedDict):
 
 class CodeLensRefreshResponse(TypedDict):
     method: Literal['workspace/codeLens/refresh']
+    params: None
     result: None
 
 
@@ -493,6 +495,7 @@ class CompletionResolveResponse(TypedDict):
 
 class ConfigurationResponse(TypedDict):
     method: Literal['workspace/configuration']
+    params: 'ConfigurationParams'
     result: List['LSPAny']
 
 
@@ -508,6 +511,7 @@ class DefinitionResponse(TypedDict):
 
 class DiagnosticRefreshResponse(TypedDict):
     method: Literal['workspace/diagnostic/refresh']
+    params: None
     result: None
 
 
@@ -568,6 +572,7 @@ class ExecuteCommandResponse(TypedDict):
 
 class FoldingRangeRefreshResponse(TypedDict):
     method: Literal['workspace/foldingRange/refresh']
+    params: None
     result: None
 
 
@@ -593,6 +598,7 @@ class InitializeResponse(TypedDict):
 
 class InlayHintRefreshResponse(TypedDict):
     method: Literal['workspace/inlayHint/refresh']
+    params: None
     result: None
 
 
@@ -613,6 +619,7 @@ class InlineCompletionResponse(TypedDict):
 
 class InlineValueRefreshResponse(TypedDict):
     method: Literal['workspace/inlineValue/refresh']
+    params: None
     result: None
 
 
@@ -643,6 +650,7 @@ class ReferencesResponse(TypedDict):
 
 class RegistrationResponse(TypedDict):
     method: Literal['client/registerCapability']
+    params: 'RegistrationParams'
     result: None
 
 
@@ -668,6 +676,7 @@ class SemanticTokensRangeResponse(TypedDict):
 
 class SemanticTokensRefreshResponse(TypedDict):
     method: Literal['workspace/semanticTokens/refresh']
+    params: None
     result: None
 
 
@@ -678,11 +687,13 @@ class SemanticTokensResponse(TypedDict):
 
 class ShowDocumentResponse(TypedDict):
     method: Literal['window/showDocument']
+    params: 'ShowDocumentParams'
     result: 'ShowDocumentResult'
 
 
 class ShowMessageResponse(TypedDict):
     method: Literal['window/showMessageRequest']
+    params: 'ShowMessageRequestParams'
     result: Union['MessageActionItem', None]
 
 
@@ -698,6 +709,7 @@ class SignatureHelpResponse(TypedDict):
 
 class TextDocumentContentRefreshResponse(TypedDict):
     method: Literal['workspace/textDocumentContent/refresh']
+    params: 'TextDocumentContentRefreshParams'
     result: None
 
 
@@ -728,6 +740,7 @@ class TypeHierarchySupertypesResponse(TypedDict):
 
 class UnregistrationResponse(TypedDict):
     method: Literal['client/unregisterCapability']
+    params: 'UnregistrationParams'
     result: None
 
 
@@ -753,6 +766,7 @@ class WillSaveTextDocumentWaitUntilResponse(TypedDict):
 
 class WorkDoneProgressCreateResponse(TypedDict):
     method: Literal['window/workDoneProgress/create']
+    params: 'WorkDoneProgressCreateParams'
     result: None
 
 
@@ -763,6 +777,7 @@ class WorkspaceDiagnosticResponse(TypedDict):
 
 class WorkspaceFoldersResponse(TypedDict):
     method: Literal['workspace/workspaceFolders']
+    params: None
     result: Union[List['WorkspaceFolder'], None]
 
 

--- a/utils/generate_requests_and_responses.py
+++ b/utils/generate_requests_and_responses.py
@@ -68,9 +68,13 @@ def generate_request(request: Request) -> tuple[str, str]:
 def generate_response(request: Request) -> tuple[str, str]:
     method = request['method']
     result = request['result']
+    params = request.get('params')
     type_name = request['typeName']
     name = f'{type_name.removesuffix("Request")}Response'
     definition = f'class {name}(TypedDict):\n'
     definition += f"{indentation}method: Literal['{method}']\n"
+    if request['messageDirection'] == 'serverToClient':
+        typ = format_type(params, {'root_symbol_name': ''}, StructureKind.Class) if params else None
+        definition += f'{indentation}params: {typ}\n'
     definition += f'{indentation}result: {format_type(result, {"root_symbol_name": ""}, StructureKind.Class)}'
     return (name, definition)


### PR DESCRIPTION
Extended the `ClientResponse` type responses with `params`.

This is for the `on_pre_send_response_async` handler added in https://github.com/sublimelsp/LSP/commit/cdf24c3b35b60cc848c7839f39bb1908a63ee003 where we also want to include the original `params` in the context of the handler.

`ClientResponse` was not used in any of the handlers before (in LSP) so it's not affecting anything existing.