### PR TITLE
cleanup: use StrEnum by default and remove overrides

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -21,21 +21,6 @@ if TYPE_CHECKING:
 
 
 ENUM_OVERRIDES: dict[str, Literal['StrEnum', 'IntFlag']] = {
-    'CodeActionKind': 'StrEnum',
-    'DocumentDiagnosticReportKind': 'StrEnum',
-    'FailureHandlingKind': 'StrEnum',
-    'FileOperationPatternKind': 'StrEnum',
-    'FoldingRangeKind': 'StrEnum',
-    'LanguageKind': 'StrEnum',
-    'MarkupKind': 'StrEnum',
-    'MonikerKind': 'StrEnum',
-    'PositionEncodingKind': 'StrEnum',
-    'ResourceOperationKind': 'StrEnum',
-    'SemanticTokenModifiers': 'StrEnum',
-    'SemanticTokenTypes': 'StrEnum',
-    'TokenFormat': 'StrEnum',
-    'TraceValue': 'StrEnum',
-    'UniquenessLevel': 'StrEnum',
     'WatchKind': 'IntFlag',
     'ApplyKind': 'IntFlag',
 }

--- a/utils/generate_enumerations.py
+++ b/utils/generate_enumerations.py
@@ -44,7 +44,7 @@ def generate_enumerations(
         documentation = format_comment(enumeration.get('documentation'), indentation)
         kind = EnumKind.String if enumeration['type']['name'] == 'string' else EnumKind.Number
         enum_class_override = overrides.get(symbol_name)
-        enum_class = enum_class_override or ('Enum' if kind == EnumKind.String else 'IntEnum')
+        enum_class = enum_class_override or ('StrEnum' if kind == EnumKind.String else 'IntEnum')
         values = format_enumeration_values(enumeration['values'], kind)
         result += f'class {symbol_name}({enum_class}):\n'
         if documentation:


### PR DESCRIPTION
Just a small cleanup - overrides for StrEnum are not needed, we can just default to it.

This produces no changes in generated files.