### PR TITLE
Add _missing_ implementation to StrEnum enums

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -68,6 +68,7 @@ def generate_protocol(output: str) -> None:
             'from typing import TypedDict',
             'from typing import Union',
             'from typing_extensions import NotRequired',
+            'from typing_extensions import override',
             'from typing_extensions import TypeAlias\n',
             'URI = str',
             'DocumentUri = str',

--- a/generated/lsp_types.py
+++ b/generated/lsp_types.py
@@ -16,6 +16,7 @@ from typing import Sequence
 from typing import TypedDict
 from typing import Union
 from typing_extensions import NotRequired
+from typing_extensions import override
 from typing_extensions import TypeAlias
 
 URI = str
@@ -32,6 +33,15 @@ class SemanticTokenTypes(StrEnum):
 
     @since 3.16.0
     """
+
+    @classmethod
+    @override
+    def _missing_(cls, value: object) -> str:
+        str_value = str(value)
+        obj = str.__new__(cls, str_value)
+        obj._value_ = str_value
+        obj._name_ = str_value
+        return obj
 
     Namespace = 'namespace'
     Type = 'type'
@@ -73,6 +83,15 @@ class SemanticTokenModifiers(StrEnum):
 
     @since 3.16.0
     """
+
+    @classmethod
+    @override
+    def _missing_(cls, value: object) -> str:
+        str_value = str(value)
+        obj = str.__new__(cls, str_value)
+        obj._value_ = str_value
+        obj._name_ = str_value
+        return obj
 
     Declaration = 'declaration'
     Definition = 'definition'
@@ -159,6 +178,15 @@ class LSPErrorCodes(IntEnum):
 
 class FoldingRangeKind(StrEnum):
     """A set of predefined range kinds."""
+
+    @classmethod
+    @override
+    def _missing_(cls, value: object) -> str:
+        str_value = str(value)
+        obj = str.__new__(cls, str_value)
+        obj._value_ = str_value
+        obj._name_ = str_value
+        return obj
 
     Comment = 'comment'
     """Folding range for a comment"""
@@ -420,6 +448,15 @@ class DocumentHighlightKind(IntEnum):
 class CodeActionKind(StrEnum):
     """A set of predefined code action kinds"""
 
+    @classmethod
+    @override
+    def _missing_(cls, value: object) -> str:
+        str_value = str(value)
+        obj = str.__new__(cls, str_value)
+        obj._value_ = str_value
+        obj._name_ = str_value
+        return obj
+
     Empty = ''
     """Empty kind."""
     QuickFix = 'quickfix'
@@ -543,6 +580,15 @@ class LanguageKind(StrEnum):
     @since 3.18.0
     """
 
+    @classmethod
+    @override
+    def _missing_(cls, value: object) -> str:
+        str_value = str(value)
+        obj = str.__new__(cls, str_value)
+        obj._value_ = str_value
+        obj._name_ = str_value
+        return obj
+
     ABAP = 'abap'
     WindowsBat = 'bat'
     BibTeX = 'bibtex'
@@ -638,6 +684,15 @@ class PositionEncodingKind(StrEnum):
 
     @since 3.17.0
     """
+
+    @classmethod
+    @override
+    def _missing_(cls, value: object) -> str:
+        str_value = str(value)
+        obj = str.__new__(cls, str_value)
+        obj._value_ = str_value
+        obj._name_ = str_value
+        return obj
 
     UTF8 = 'utf-8'
     """Character offsets count UTF-8 code units (e.g. bytes)."""

--- a/utils/generate_enumerations.py
+++ b/utils/generate_enumerations.py
@@ -13,6 +13,18 @@ if TYPE_CHECKING:
     from lsp_schema import EnumerationEntry
 
 
+STR_ENUM_MISSING_IMPL = f"""
+@classmethod
+@override
+def _missing_(cls, value: object) -> str:
+{indentation}str_value = str(value)
+{indentation}obj = str.__new__(cls, str_value)
+{indentation}obj._value_ = str_value
+{indentation}obj._name_ = str_value
+{indentation}return obj
+""".strip()
+
+
 class EnumKind(Enum):
     Number = 1
     String = 2
@@ -49,6 +61,10 @@ def generate_enumerations(
         result += f'class {symbol_name}({enum_class}):\n'
         if documentation:
             result += f'{documentation}\n\n'
+        if enum_class == 'StrEnum' and enumeration.get('supportsCustomValues'):
+            lines = STR_ENUM_MISSING_IMPL.splitlines()
+            formatted = '\n'.join([f'{indentation}{line}' for line in lines])
+            result += f'{formatted}\n\n'
         result += f'{indentation}' + values
         return result
 


### PR DESCRIPTION
Add `_missing_` implementation for string enumerations that have `supportsCustomValues` specified in schema.

`LSP-json` has a [code that assigns custom language ID](https://github.com/sublimelsp/LSP-json/blob/14056f04acc02bb2199daaaf1792eb0a132adbc6/plugin.py#L95-L96) to `TextDocument.languageId`. That triggers a type error:

> Could not assign item in TypedDict. "Literal['jsonc']" is not assignable to "LanguageKind" (reportGeneralTypeIssues)

Adding `_missing_` implementation allows us to use a code like:

```py
text_document['languageId'] = LanguageKind('jsonc')
```

to set custom language ID without triggering type error.